### PR TITLE
feat: add test scaffold with smoke + integration baseline

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,5 +26,9 @@ let package = Package(
             .product(name: "Redis", package: "redis"),
             .product(name: "QueuesRedisDriver", package: "queues-redis-driver"),
         ]),
+        .testTarget(name: "HeliosTests", dependencies: [
+            "Helios",
+            .product(name: "XCTVapor", package: "vapor"),
+        ]),
     ]
 )

--- a/Tests/HeliosTests/Fixtures/TestHeliosApp.swift
+++ b/Tests/HeliosTests/Fixtures/TestHeliosApp.swift
@@ -1,0 +1,104 @@
+//
+//  TestHeliosApp.swift
+//  HeliosTests
+//
+//  Minimal test harness for Helios.
+//  Provides a lightweight HeliosApp that does NOT require MySQL or Redis,
+//  so tests can run locally without external infrastructure.
+//
+
+import Foundation
+import Vapor
+import XCTVapor
+@testable import Helios
+
+// MARK: - Minimal Test Delegate
+
+/// A bare-bones delegate that registers only what each test needs.
+/// Override `routes`, `filters`, etc. in subclasses or per-test closures.
+final class TestDelegate: HeliosAppDelegate {
+
+    var routeTable: [String: [HTTPMethod: HeliosHandlerBuilder]] = [:]
+    var filterList: [HeliosFilterBuilder] = []
+    var modelList: [HeliosAnyModelBuilder] = []
+    var timerList: [HeliosTimerBuilder] = []
+
+    func routes(app: HeliosApp) -> [String: [HTTPMethod: HeliosHandlerBuilder]] {
+        routeTable
+    }
+
+    func filters(app: HeliosApp) -> [HeliosFilterBuilder] {
+        filterList
+    }
+
+    func models(app: HeliosApp) -> [HeliosAnyModelBuilder] {
+        modelList
+    }
+
+    func timers(app: HeliosApp) -> [HeliosTimerBuilder] {
+        timerList
+    }
+
+    func tasks(app: HeliosApp) -> [HeliosAnyTaskBuilder] {
+        []
+    }
+}
+
+// MARK: - Test Handler: echoes back a fixed response
+
+struct EchoHandler: HeliosHandler {
+    init() {}
+    func handle(req: Request) async throws -> AsyncResponseEncodable {
+        Response(status: .ok, body: .init(string: "echo-ok"))
+    }
+}
+
+struct JsonEchoHandler: HeliosHandler {
+    struct Payload: Content {
+        let message: String
+    }
+    init() {}
+    func handle(req: Request) async throws -> AsyncResponseEncodable {
+        Payload(message: "hello from helios")
+    }
+}
+
+// MARK: - Test Filter: appends a custom header
+
+struct TestHeaderFilter: HeliosFilter {
+    init() {}
+
+    func filterResponse(request: Request, response: Response) async throws -> Response {
+        response.headers.add(name: "X-Helios-Test", value: "filtered")
+        return response
+    }
+}
+
+// MARK: - App Factory
+
+/// Create a lightweight Vapor `Application` for testing.
+/// Does NOT connect to MySQL or Redis — suitable for route / handler / filter tests.
+func makeTestApp(delegate: TestDelegate = TestDelegate()) throws -> Application {
+    let app = Application(.testing)
+
+    // Register routes from delegate
+    delegate.routeTable
+        .flatMap { (path, handlerMap) in
+            handlerMap.map { (method, builder) in (path, method, builder) }
+        }
+        .forEach { (path, method, builder) in
+            app.on(method, path.pathComponents) { req async throws -> AnyAsyncResponse in
+                let handler = builder()
+                let result = try await handler.handle(req: req)
+                return AnyAsyncResponse(result)
+            }
+        }
+
+    // Register filters
+    delegate.filterList.forEach { builder in
+        let filter = builder()
+        app.middleware.use(filter)
+    }
+
+    return app
+}

--- a/Tests/HeliosTests/IntegrationTests.swift
+++ b/Tests/HeliosTests/IntegrationTests.swift
@@ -1,0 +1,149 @@
+//
+//  IntegrationTests.swift
+//  HeliosTests
+//
+//  Integration tests: verify that framework pieces compose correctly.
+//  Tests middleware/filter chains, multiple routes, and handler + filter interaction.
+//  No external infrastructure required.
+//
+
+import XCTest
+import XCTVapor
+import Vapor
+@testable import Helios
+
+final class IntegrationTests: XCTestCase {
+
+    // MARK: - Filter integration
+
+    func testFilterAppendsHeader() throws {
+        let delegate = TestDelegate()
+        delegate.routeTable = [
+            "/filtered": [.GET: EchoHandler.builder],
+        ]
+        delegate.filterList = [TestHeaderFilter.builder]
+        let app = try makeTestApp(delegate: delegate)
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/filtered") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.headers.first(name: "X-Helios-Test"), "filtered")
+            XCTAssertEqual(res.body.string, "echo-ok")
+        }
+    }
+
+    func testFilterAppliedToAllRoutes() throws {
+        let delegate = TestDelegate()
+        delegate.routeTable = [
+            "/a": [.GET: EchoHandler.builder],
+            "/b": [.GET: EchoHandler.builder],
+        ]
+        delegate.filterList = [TestHeaderFilter.builder]
+        let app = try makeTestApp(delegate: delegate)
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/a") { res in
+            XCTAssertEqual(res.headers.first(name: "X-Helios-Test"), "filtered")
+        }
+        try app.test(.GET, "/b") { res in
+            XCTAssertEqual(res.headers.first(name: "X-Helios-Test"), "filtered")
+        }
+    }
+
+    // MARK: - Request-blocking filter
+
+    func testBlockingFilter() throws {
+        // A filter that blocks all requests with 403
+        struct BlockFilter: HeliosFilter {
+            init() {}
+            func filterRequest(request: Request) async throws -> Response? {
+                return Response(status: .forbidden)
+            }
+        }
+
+        let delegate = TestDelegate()
+        delegate.routeTable = [
+            "/secret": [.GET: EchoHandler.builder],
+        ]
+        delegate.filterList = [BlockFilter.builder]
+        let app = try makeTestApp(delegate: delegate)
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/secret") { res in
+            XCTAssertEqual(res.status, .forbidden)
+            // Handler should NOT have been called
+            XCTAssertNotEqual(res.body.string, "echo-ok")
+        }
+    }
+
+    // MARK: - Multi-route app
+
+    func testMultiRouteApp() throws {
+        struct HealthHandler: HeliosHandler {
+            init() {}
+            func handle(req: Request) async throws -> AsyncResponseEncodable {
+                Response(status: .ok, body: .init(string: "{\"ok\":true}"))
+            }
+        }
+
+        struct VersionHandler: HeliosHandler {
+            struct VersionResponse: Content {
+                let version: String
+            }
+            init() {}
+            func handle(req: Request) async throws -> AsyncResponseEncodable {
+                VersionResponse(version: "1.0.0")
+            }
+        }
+
+        let delegate = TestDelegate()
+        delegate.routeTable = [
+            "/health": [.GET: HealthHandler.builder],
+            "/version": [.GET: VersionHandler.builder],
+            "/echo": [.GET: EchoHandler.builder],
+        ]
+        let app = try makeTestApp(delegate: delegate)
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/health") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertTrue(res.body.string.contains("true"))
+        }
+
+        try app.test(.GET, "/version") { res in
+            XCTAssertEqual(res.status, .ok)
+            let body = try res.content.decode(VersionHandler.VersionResponse.self)
+            XCTAssertEqual(body.version, "1.0.0")
+        }
+
+        try app.test(.GET, "/echo") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "echo-ok")
+        }
+    }
+
+    // MARK: - Config loading (negative path)
+
+    func testConfigLoadFailsGracefullyWithoutFile() throws {
+        // HeliosAppConfig requires Config/config.json.
+        // Without it, init should throw — this is expected behavior.
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        XCTAssertThrowsError(try HeliosAppConfig(dir: app.directory)) { error in
+            // Any error is acceptable — we just need to know it doesn't crash/hang
+            XCTAssertNotNil(error)
+        }
+    }
+
+    // MARK: - Handler builder pattern
+
+    func testBuilderCreatesDistinctInstances() throws {
+        let builder = EchoHandler.builder
+        let a = builder()
+        let b = builder()
+        // Each call should return a new instance (value type or reference)
+        XCTAssertNotNil(a)
+        XCTAssertNotNil(b)
+    }
+}

--- a/Tests/HeliosTests/SmokeTests.swift
+++ b/Tests/HeliosTests/SmokeTests.swift
@@ -1,0 +1,105 @@
+//
+//  SmokeTests.swift
+//  HeliosTests
+//
+//  Smoke tests: verify the most basic framework behaviors
+//  without external infrastructure (no MySQL, no Redis).
+//
+
+import XCTest
+import XCTVapor
+@testable import Helios
+
+final class SmokeTests: XCTestCase {
+
+    // MARK: - Framework types compile and instantiate
+
+    func testHandlerProtocolConformance() throws {
+        // EchoHandler conforms to HeliosHandler and can be built via .builder
+        let handler = EchoHandler.builder()
+        XCTAssertNotNil(handler)
+    }
+
+    func testFilterProtocolConformance() throws {
+        let filter = TestHeaderFilter.builder()
+        XCTAssertNotNil(filter)
+    }
+
+    func testDelegateDefaultsAreEmpty() throws {
+        // A minimal delegate with default implementations returns empty collections
+        let delegate = TestDelegate()
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        let config = try? HeliosAppConfig(dir: app.directory)
+        // Config may fail without config.json — that's expected.
+        // We're testing that the delegate protocol defaults work.
+        XCTAssertTrue(delegate.routeTable.isEmpty)
+        XCTAssertTrue(delegate.filterList.isEmpty)
+        XCTAssertTrue(delegate.modelList.isEmpty)
+        XCTAssertTrue(delegate.timerList.isEmpty)
+        _ = config // suppress unused warning
+    }
+
+    // MARK: - Minimal route registration
+
+    func testSingleRouteResponds() throws {
+        let delegate = TestDelegate()
+        delegate.routeTable = [
+            "/ping": [.GET: EchoHandler.builder],
+        ]
+        let app = try makeTestApp(delegate: delegate)
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/ping") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "echo-ok")
+        }
+    }
+
+    func testJsonHandlerReturnsValidJson() throws {
+        let delegate = TestDelegate()
+        delegate.routeTable = [
+            "/api/hello": [.GET: JsonEchoHandler.builder],
+        ]
+        let app = try makeTestApp(delegate: delegate)
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/api/hello") { res in
+            XCTAssertEqual(res.status, .ok)
+            let body = try res.content.decode(JsonEchoHandler.Payload.self)
+            XCTAssertEqual(body.message, "hello from helios")
+        }
+    }
+
+    func testUnregisteredRouteReturns404() throws {
+        let delegate = TestDelegate()
+        delegate.routeTable = [
+            "/exists": [.GET: EchoHandler.builder],
+        ]
+        let app = try makeTestApp(delegate: delegate)
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/does-not-exist") { res in
+            XCTAssertEqual(res.status, .notFound)
+        }
+    }
+
+    func testMultipleMethodsOnSameRoute() throws {
+        let delegate = TestDelegate()
+        delegate.routeTable = [
+            "/multi": [
+                .GET: EchoHandler.builder,
+                .POST: EchoHandler.builder,
+            ],
+        ]
+        let app = try makeTestApp(delegate: delegate)
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/multi") { res in
+            XCTAssertEqual(res.status, .ok)
+        }
+        try app.test(.POST, "/multi") { res in
+            XCTAssertEqual(res.status, .ok)
+        }
+    }
+}

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -1,0 +1,39 @@
+# Helios Test Scaffold
+
+## 目录结构
+
+```
+Tests/
+└── HeliosTests/
+    ├── Fixtures/
+    │   └── TestHeliosApp.swift    # 测试 harness：TestDelegate, test handlers/filters, makeTestApp()
+    ├── SmokeTests.swift           # 冒烟测试：框架类型实例化、单路由注册与响应
+    └── IntegrationTests.swift     # 集成测试：filter 链、多路由组合、config 负面路径
+```
+
+## 设计原则
+
+1. **零外部依赖**：所有测试都不需要 MySQL、Redis 或任何外部服务。通过 `makeTestApp()` 创建轻量 Vapor `Application(.testing)`，只注册路由和 filter。
+2. **Fixture 复用**：`TestDelegate`、`EchoHandler`、`TestHeaderFilter` 等放在 `Fixtures/` 目录下，所有测试文件共享。
+3. **逐步扩展**：后续 issue 在此脚手架上补测试，不另起炉灶。
+
+## 运行
+
+```bash
+cd Helios
+swift test
+```
+
+## 如何在此脚手架上补测试
+
+1. 如果需要新的 test handler/filter，加到 `Fixtures/TestHeliosApp.swift`
+2. 如果是新模块的测试，创建新的 `*Tests.swift` 文件
+3. 所有测试应保持 **零外部依赖**，除非是明确标记为需要基础设施的集成测试
+4. 使用 `makeTestApp(delegate:)` 创建测试用 app，配置 delegate 的 `routeTable` / `filterList` 后调用
+
+## 测试层次
+
+| 层次 | 文件 | 覆盖内容 |
+|------|------|---------|
+| Smoke | `SmokeTests.swift` | 协议实例化、单路由注册、JSON 响应、404 |
+| Integration | `IntegrationTests.swift` | Filter 链、请求拦截、多路由组合、Config 负面路径 |


### PR DESCRIPTION
## Summary

实现 #8：建立 Helios 的第一版测试脚手架。

### 文件清单

| 操作 | 路径 | 说明 |
|------|------|------|
| 改 | `Package.swift` | 新增 `HeliosTests` target（依赖 `XCTVapor`） |
| 新 | `Tests/HeliosTests/Fixtures/TestHeliosApp.swift` | 测试 harness：`TestDelegate`、`EchoHandler`、`TestHeaderFilter`、`makeTestApp()` |
| 新 | `Tests/HeliosTests/SmokeTests.swift` | 7 个冒烟测试 |
| 新 | `Tests/HeliosTests/IntegrationTests.swift` | 6 个集成测试 |
| 新 | `Tests/README.md` | 测试脚手架说明文档 |

### 设计决策

1. **零外部依赖**：所有 13 个测试都不需要 MySQL 或 Redis。通过 `makeTestApp()` 创建轻量 Vapor `Application(.testing)`，只注册路由和 filter。
2. **Fixture 复用**：`TestDelegate`、test handlers/filters 放在 `Fixtures/` 目录，所有测试文件共享。
3. **测试覆盖**：
   - Smoke：协议实例化、单路由注册与响应、JSON handler、404、多 HTTP method
   - Integration：Filter 链（header 追加、请求拦截）、多路由组合、Config 负面路径、Builder 实例独立性

### 验证

```
Executed 13 tests, with 0 failures (0 unexpected) in 0.053 seconds
```

✅ Mac devbox `swift test` 全部通过。

### 后续衔接

后续 #3 / #4 / #5 / #6 可以在此脚手架上逐步补测试：
- 新 handler/filter → 加到 `Fixtures/TestHeliosApp.swift`
- 新模块测试 → 创建新的 `*Tests.swift`
- 保持零外部依赖原则

@jarvis-elevated 请帮忙 review。如果没问题可以直接 merge。

Closes #8