### PR TITLE
refactor: extract shared route/filter registrar

### DIFF
--- a/Sources/Helios/App/HeliosApp.swift
+++ b/Sources/Helios/App/HeliosApp.swift
@@ -65,18 +65,7 @@ public final class HeliosApp {
         app.queues.use(.redis(redisConfiguration))
 
         // Routes
-        delegate.routes(app: self)
-            .flatMap { (path: String, handlerMapper: [HTTPMethod : HeliosHandlerBuilder]) in
-                handlerMapper.map { (method: HTTPMethod, builder: @escaping HeliosHandlerBuilder) in
-                    (path, method, builder)
-                }
-            }.forEach { (path, method, builder) in
-                app.on(method, path.pathComponents) { req async throws -> AnyAsyncResponse in
-                    let handler = builder()
-                    let result = try await handler.handle(req: req)
-                    return AnyAsyncResponse(result)
-                }
-            }
+        HeliosRouteRegistrar.registerRoutes(delegate.routes(app: self), on: app)
 
         // Model / Migration
         delegate.models(app: self).forEach { builder in
@@ -88,10 +77,7 @@ public final class HeliosApp {
         app.views.use(.leaf)
 
         // Filter / Middleware
-        delegate.filters(app: self).forEach { builder in
-            let plugin = builder()
-            app.middleware.use(plugin)
-        }
+        HeliosRouteRegistrar.registerFilters(delegate.filters(app: self), on: app)
         app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
 
         // Timer

--- a/Sources/Helios/App/HeliosRouteRegistrar.swift
+++ b/Sources/Helios/App/HeliosRouteRegistrar.swift
@@ -1,0 +1,44 @@
+//
+//  HeliosRouteRegistrar.swift
+//  Helios
+//
+//  Shared route + filter registration logic used by both HeliosApp (production)
+//  and the test harness, so registration semantics stay in sync.
+//
+
+import Foundation
+import Vapor
+
+public enum HeliosRouteRegistrar {
+
+    /// Register handler-based routes on a Vapor `Application`.
+    public static func registerRoutes(
+        _ routes: [String: [HTTPMethod: HeliosHandlerBuilder]],
+        on app: Application
+    ) {
+        routes
+            .flatMap { (path: String, handlerMap: [HTTPMethod: HeliosHandlerBuilder]) in
+                handlerMap.map { (method: HTTPMethod, builder: @escaping HeliosHandlerBuilder) in
+                    (path, method, builder)
+                }
+            }
+            .forEach { (path, method, builder) in
+                app.on(method, path.pathComponents) { req async throws -> AnyAsyncResponse in
+                    let handler = builder()
+                    let result = try await handler.handle(req: req)
+                    return AnyAsyncResponse(result)
+                }
+            }
+    }
+
+    /// Register filters (middleware) on a Vapor `Application`.
+    public static func registerFilters(
+        _ filters: [HeliosFilterBuilder],
+        on app: Application
+    ) {
+        filters.forEach { builder in
+            let filter = builder()
+            app.middleware.use(filter)
+        }
+    }
+}

--- a/Tests/HeliosTests/Fixtures/TestHeliosApp.swift
+++ b/Tests/HeliosTests/Fixtures/TestHeliosApp.swift
@@ -81,24 +81,9 @@ struct TestHeaderFilter: HeliosFilter {
 func makeTestApp(delegate: TestDelegate = TestDelegate()) throws -> Application {
     let app = Application(.testing)
 
-    // Register routes from delegate
-    delegate.routeTable
-        .flatMap { (path, handlerMap) in
-            handlerMap.map { (method, builder) in (path, method, builder) }
-        }
-        .forEach { (path, method, builder) in
-            app.on(method, path.pathComponents) { req async throws -> AnyAsyncResponse in
-                let handler = builder()
-                let result = try await handler.handle(req: req)
-                return AnyAsyncResponse(result)
-            }
-        }
-
-    // Register filters
-    delegate.filterList.forEach { builder in
-        let filter = builder()
-        app.middleware.use(filter)
-    }
+    // Use the same registrar as production HeliosApp
+    HeliosRouteRegistrar.registerRoutes(delegate.routeTable, on: app)
+    HeliosRouteRegistrar.registerFilters(delegate.filterList, on: app)
 
     return app
 }


### PR DESCRIPTION
## Summary

PR #9 review 中 Jarvis 指出 `makeTestApp()` 里的路由/filter 注册逻辑和 `HeliosApp.setup()` 重复，有漂移风险。

### Changes

- 新增 `HeliosRouteRegistrar`（public enum），提供 `registerRoutes()` 和 `registerFilters()`
- `HeliosApp.setup()`：改用 `HeliosRouteRegistrar` 注册路由和 filter
- `makeTestApp()`：同样改用 `HeliosRouteRegistrar`

生产和测试现在走同一条注册主线。

### 验证

```
Executed 13 tests, with 0 failures (0 unexpected) in 0.070 seconds
```

@jarvis-elevated 请帮忙 review，如果没问题可以直接 merge。