### PR TITLE
feat: typed config system with layered loading and fail-fast validation

### DIFF
--- a/Config/base.example.json
+++ b/Config/base.example.json
@@ -1,0 +1,25 @@
+{
+    "server": {
+        "host": "0.0.0.0",
+        "port": 8080
+    },
+    "mysql": {
+        "host": "127.0.0.1",
+        "port": 3306,
+        "username": "root",
+        "password": "",
+        "database": "helios_dev",
+        "tls": "disable"
+    },
+    "redis": {
+        "host": "127.0.0.1",
+        "port": 6379
+    },
+    "features": {
+        "autoMigrate": true,
+        "serveLeaf": true,
+        "enableQueues": true,
+        "enableTimers": true,
+        "serveStaticFiles": true
+    }
+}

--- a/Config/production.example.json
+++ b/Config/production.example.json
@@ -1,0 +1,12 @@
+{
+    "server": {
+        "host": "0.0.0.0",
+        "port": 8080
+    },
+    "mysql": {
+        "tls": "require"
+    },
+    "features": {
+        "autoMigrate": false
+    }
+}

--- a/Sources/Helios/App/HeliosApp.swift
+++ b/Sources/Helios/App/HeliosApp.swift
@@ -35,34 +35,43 @@ public final class HeliosApp {
     }
 
     private func setup() throws {
+        let c = config.typed
 
-        // Service
-        app.http.server.configuration.hostname = config.hostname.isEmpty ? HTTPServer.Configuration.defaultHostname : config.hostname
-        app.http.server.configuration.port = Int(config.port) ?? HTTPServer.Configuration.defaultPort
+        // Server
+        app.http.server.configuration.hostname = c.server.host
+        app.http.server.configuration.port = c.server.port
 
         // Database
-        var tslConfig = TLSConfiguration.makeClientConfiguration()
-        tslConfig.certificateVerification = .none
+        var tlsConfig = TLSConfiguration.makeClientConfiguration()
+        switch c.mysql.tls {
+        case .disable:
+            tlsConfig.certificateVerification = .none
+        case .require:
+            break // keep system default (full verification)
+        }
         app.databases.use(
             .mysql(
-                hostname: config.mysql_host,
-                port: Int(config.mysql_port) ?? 3306,
-                username: config.mysql_username,
-                password: config.mysql_password,
-                database: config.mysql_database,
-                tlsConfiguration: tslConfig
+                hostname: c.mysql.host,
+                port: c.mysql.port,
+                username: c.mysql.username,
+                password: c.mysql.password,
+                database: c.mysql.database,
+                tlsConfiguration: tlsConfig
             ),
             as: .mysql
         )
 
         // Redis / Queues
         let redisConfiguration = try RedisConfiguration(
-            hostname: config.redis_host,
-            port: Int(config.redis_port) ?? RedisConnection.Configuration.defaultPort,
+            hostname: c.redis.host,
+            port: c.redis.port,
             pool: .init(connectionRetryTimeout: .seconds(1))
         )
         app.redis.configuration = redisConfiguration
-        app.queues.use(.redis(redisConfiguration))
+
+        if c.features.enableQueues {
+            app.queues.use(.redis(redisConfiguration))
+        }
 
         // Routes
         HeliosRouteRegistrar.registerRoutes(delegate.routes(app: self), on: app)
@@ -74,33 +83,46 @@ public final class HeliosApp {
         }
 
         // Views
-        app.views.use(.leaf)
+        if c.features.serveLeaf {
+            app.views.use(.leaf)
+        }
 
         // Filter / Middleware
         HeliosRouteRegistrar.registerFilters(delegate.filters(app: self), on: app)
-        app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
 
-        // Timer
-        delegate.timers(app: self).forEach { builder in
-            let timer = builder()
-            timer.schedule(queue: app.queues)
+        if c.features.serveStaticFiles {
+            app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
         }
 
-        // Task
-        delegate.tasks(app: self).forEach { builder in
-            guard let task = builder() as? any HeliosTask else {
-                app.logger.critical("Unrecognized task builder: \(String(describing: builder))")
-                return
+        // Timer — only when queues are enabled
+        if c.features.enableQueues && c.features.enableTimers {
+            delegate.timers(app: self).forEach { builder in
+                let timer = builder()
+                timer.schedule(queue: app.queues)
             }
-            task.register(queue: app.queues)
         }
 
+        // Task — only when queues are enabled
+        if c.features.enableQueues {
+            delegate.tasks(app: self).forEach { builder in
+                guard let task = builder() as? any HeliosTask else {
+                    app.logger.critical("Unrecognized task builder: \(String(describing: builder))")
+                    return
+                }
+                task.register(queue: app.queues)
+            }
+        }
     }
 
     public func run() throws {
-        try app.autoMigrate().wait()
-        try app.queues.startInProcessJobs()
-        try app.queues.startScheduledJobs()
+        let c = config.typed
+        if c.features.autoMigrate {
+            try app.autoMigrate().wait()
+        }
+        if c.features.enableQueues {
+            try app.queues.startInProcessJobs()
+            try app.queues.startScheduledJobs()
+        }
         try app.run()
     }
 
@@ -121,5 +143,4 @@ extension HeliosApp {
         try helios.setup()
         return helios
     }
-
 }

--- a/Sources/Helios/Base/HeliosAppConfig.swift
+++ b/Sources/Helios/Base/HeliosAppConfig.swift
@@ -1,24 +1,24 @@
 //
 //  HeliosAppConfig.swift
-//  
+//  Helios
 //
-//  Created by Yuu Zheng on 12/29/22.
+//  Thin facade that loads typed config and exposes workspace paths.
+//  Replaces the old [String: String] + @dynamicMemberLookup approach.
 //
 
 import Foundation
 import Vapor
 
-@dynamicMemberLookup
 public final class HeliosAppConfig {
 
     public let workspacePath: String
-
     public let publicPath: String
     public let viewsPath: String
     public let resourcesPath: String
-    public var configPath: String
+    public let configPath: String
 
-    public let config: [String: String]
+    /// The typed configuration loaded from JSON + env vars.
+    public let typed: HeliosConfig
 
     public init(dir: DirectoryConfiguration) throws {
         workspacePath = dir.workingDirectory
@@ -27,13 +27,16 @@ public final class HeliosAppConfig {
         resourcesPath = dir.resourcesDirectory
         configPath = workspacePath + "Config/"
 
-        let url = URL(fileURLWithPath: configPath + "config.json")
-        let data = try Data(contentsOf: url)
-        config = try JSONDecoder().decode([String: String].self, from: data)
+        typed = try HeliosConfigLoader.load(configDir: configPath)
     }
 
-    public subscript(dynamicMember name: String) -> String {
-        return config[name] ?? ""
+    /// Test-only initializer: inject a pre-built config without loading from disk.
+    public init(workspacePath: String, config: HeliosConfig) {
+        self.workspacePath = workspacePath
+        self.publicPath = workspacePath + "Public/"
+        self.viewsPath = workspacePath + "Views/"
+        self.resourcesPath = workspacePath + "Resources/"
+        self.configPath = workspacePath + "Config/"
+        self.typed = config
     }
 }
-

--- a/Sources/Helios/Base/HeliosConfig.swift
+++ b/Sources/Helios/Base/HeliosConfig.swift
@@ -1,0 +1,111 @@
+//
+//  HeliosConfig.swift
+//  Helios
+//
+//  Typed configuration model for Helios.
+//  Replaces the old [String: String] + @dynamicMemberLookup approach.
+//
+
+import Foundation
+
+// MARK: - Top-level Config
+
+public struct HeliosConfig {
+    public let server: ServerConfig
+    public let mysql: MySQLConfig
+    public let redis: RedisConfig
+    public let features: FeatureFlags
+
+    public init(server: ServerConfig, mysql: MySQLConfig, redis: RedisConfig, features: FeatureFlags) {
+        self.server = server
+        self.mysql = mysql
+        self.redis = redis
+        self.features = features
+    }
+}
+
+// MARK: - Sub-configs
+
+public struct ServerConfig {
+    public let host: String
+    public let port: Int
+
+    public init(host: String = "0.0.0.0", port: Int = 8080) {
+        self.host = host
+        self.port = port
+    }
+}
+
+public struct MySQLConfig {
+    public let host: String
+    public let port: Int
+    public let username: String
+    public let password: String
+    public let database: String
+    public let tls: TLSMode
+
+    public init(host: String, port: Int = 3306, username: String, password: String, database: String, tls: TLSMode = .disable) {
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.database = database
+        self.tls = tls
+    }
+}
+
+public struct RedisConfig {
+    public let host: String
+    public let port: Int
+
+    public init(host: String = "127.0.0.1", port: Int = 6379) {
+        self.host = host
+        self.port = port
+    }
+}
+
+public struct FeatureFlags {
+    public let autoMigrate: Bool
+    public let serveLeaf: Bool
+    public let enableQueues: Bool
+    public let enableTimers: Bool
+    public let serveStaticFiles: Bool
+
+    public init(
+        autoMigrate: Bool = false,
+        serveLeaf: Bool = true,
+        enableQueues: Bool = true,
+        enableTimers: Bool = true,
+        serveStaticFiles: Bool = true
+    ) {
+        self.autoMigrate = autoMigrate
+        self.serveLeaf = serveLeaf
+        self.enableQueues = enableQueues
+        self.enableTimers = enableTimers
+        self.serveStaticFiles = serveStaticFiles
+    }
+}
+
+// MARK: - Enums
+
+public enum TLSMode: String, Codable {
+    case disable
+    case require
+}
+
+public enum AppEnv: String, Codable {
+    case development
+    case production
+    case testing
+
+    public static func detect() -> AppEnv {
+        let raw = ProcessInfo.processInfo.environment["HELIOS_ENV"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+        switch raw {
+        case "production", "prod": return .production
+        case "testing", "test": return .testing
+        default: return .development
+        }
+    }
+}

--- a/Sources/Helios/Base/HeliosConfigLoader.swift
+++ b/Sources/Helios/Base/HeliosConfigLoader.swift
@@ -1,0 +1,228 @@
+//
+//  HeliosConfigLoader.swift
+//  Helios
+//
+//  Three-layer config loading: base.json → <env>.json → environment variables.
+//  Falls back to legacy config.json for backward compatibility.
+//
+
+import Foundation
+
+public enum HeliosConfigLoader {
+
+    // MARK: - Public API
+
+    /// Load, merge, validate, and return a typed `HeliosConfig`.
+    /// Throws `HeliosConfigError` on missing required fields or invalid values.
+    public static func load(configDir: String) throws -> HeliosConfig {
+        let env = AppEnv.detect()
+        let dir = configDir.hasSuffix("/") ? configDir : configDir + "/"
+
+        // Layer 1: base config
+        var base = try loadJSON(at: dir, fileName: "base.json")
+            ?? loadJSON(at: dir, fileName: "config.json")  // legacy fallback
+            ?? [:]
+
+        // Layer 2: environment override (e.g. production.json, development.json)
+        if let envOverride = try loadJSON(at: dir, fileName: "\(env.rawValue).json") {
+            base = merge(base: base, override: envOverride)
+        }
+
+        // Layer 3: environment variables
+        applyEnvVars(to: &base)
+
+        // Build typed config
+        let config = try build(from: base, env: env)
+
+        // Validate
+        try validate(config, env: env)
+
+        return config
+    }
+
+    // MARK: - JSON Loading
+
+    private static func loadJSON(at dir: String, fileName: String) throws -> [String: Any]? {
+        let url = URL(fileURLWithPath: dir + fileName)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        let data = try Data(contentsOf: url)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw HeliosConfigError.invalidFormat(fileName)
+        }
+        return json
+    }
+
+    // MARK: - Merge
+
+    /// Shallow-merge override into base. Override values win.
+    /// Supports nested dictionaries (one level deep).
+    private static func merge(base: [String: Any], override: [String: Any]) -> [String: Any] {
+        var result = base
+        for (key, value) in override {
+            if let baseDict = result[key] as? [String: Any],
+               let overrideDict = value as? [String: Any] {
+                result[key] = merge(base: baseDict, override: overrideDict)
+            } else {
+                result[key] = value
+            }
+        }
+        return result
+    }
+
+    // MARK: - Environment Variables
+
+    /// Explicit env var whitelist. Only these keys are recognized.
+    private static let envVarMapping: [(envKey: String, configPath: [String])] = [
+        ("HELIOS_SERVER_HOST",     ["server", "host"]),
+        ("HELIOS_SERVER_PORT",     ["server", "port"]),
+        ("HELIOS_MYSQL_HOST",      ["mysql", "host"]),
+        ("HELIOS_MYSQL_PORT",      ["mysql", "port"]),
+        ("HELIOS_MYSQL_USERNAME",  ["mysql", "username"]),
+        ("HELIOS_MYSQL_PASSWORD",  ["mysql", "password"]),
+        ("HELIOS_MYSQL_DATABASE",  ["mysql", "database"]),
+        ("HELIOS_MYSQL_TLS",       ["mysql", "tls"]),
+        ("HELIOS_REDIS_HOST",      ["redis", "host"]),
+        ("HELIOS_REDIS_PORT",      ["redis", "port"]),
+        ("HELIOS_AUTO_MIGRATE",    ["features", "autoMigrate"]),
+    ]
+
+    private static func applyEnvVars(to config: inout [String: Any]) {
+        let env = ProcessInfo.processInfo.environment
+        for mapping in envVarMapping {
+            guard let value = env[mapping.envKey], !value.isEmpty else { continue }
+            setNestedValue(in: &config, path: mapping.configPath, value: value)
+        }
+    }
+
+    private static func setNestedValue(in dict: inout [String: Any], path: [String], value: Any) {
+        guard !path.isEmpty else { return }
+        if path.count == 1 {
+            dict[path[0]] = value
+            return
+        }
+        var nested = dict[path[0]] as? [String: Any] ?? [:]
+        setNestedValue(in: &nested, path: Array(path.dropFirst()), value: value)
+        dict[path[0]] = nested
+    }
+
+    // MARK: - Build Typed Config
+
+    private static func build(from raw: [String: Any], env: AppEnv) throws -> HeliosConfig {
+        // Server
+        let serverRaw = raw["server"] as? [String: Any] ?? [:]
+        // Legacy flat key fallback
+        let serverHost = stringValue(serverRaw["host"]) ?? stringValue(raw["hostname"]) ?? "0.0.0.0"
+        let serverPort = intValue(serverRaw["port"]) ?? intValue(raw["port"]) ?? 8080
+
+        // MySQL
+        let mysqlRaw = raw["mysql"] as? [String: Any] ?? [:]
+        let mysqlHost = stringValue(mysqlRaw["host"]) ?? stringValue(raw["mysql_host"]) ?? ""
+        let mysqlPort = intValue(mysqlRaw["port"]) ?? intValue(raw["mysql_port"]) ?? 3306
+        let mysqlUsername = stringValue(mysqlRaw["username"]) ?? stringValue(raw["mysql_username"]) ?? ""
+        let mysqlPassword = stringValue(mysqlRaw["password"]) ?? stringValue(raw["mysql_password"]) ?? ""
+        let mysqlDatabase = stringValue(mysqlRaw["database"]) ?? stringValue(raw["mysql_database"]) ?? ""
+        let mysqlTLS = TLSMode(rawValue: stringValue(mysqlRaw["tls"]) ?? "disable") ?? .disable
+
+        // Redis
+        let redisRaw = raw["redis"] as? [String: Any] ?? [:]
+        let redisHost = stringValue(redisRaw["host"]) ?? stringValue(raw["redis_host"]) ?? "127.0.0.1"
+        let redisPort = intValue(redisRaw["port"]) ?? intValue(raw["redis_port"]) ?? 6379
+
+        // Features
+        let featuresRaw = raw["features"] as? [String: Any] ?? [:]
+        let autoMigrate = boolValue(featuresRaw["autoMigrate"]) ?? boolValue(raw["auto_migrate"]) ?? false
+        let serveLeaf = boolValue(featuresRaw["serveLeaf"]) ?? true
+        let enableQueues = boolValue(featuresRaw["enableQueues"]) ?? true
+        let enableTimers = boolValue(featuresRaw["enableTimers"]) ?? true
+        let serveStaticFiles = boolValue(featuresRaw["serveStaticFiles"]) ?? true
+
+        return HeliosConfig(
+            server: ServerConfig(host: serverHost, port: serverPort),
+            mysql: MySQLConfig(host: mysqlHost, port: mysqlPort, username: mysqlUsername, password: mysqlPassword, database: mysqlDatabase, tls: mysqlTLS),
+            redis: RedisConfig(host: redisHost, port: redisPort),
+            features: FeatureFlags(autoMigrate: autoMigrate, serveLeaf: serveLeaf, enableQueues: enableQueues, enableTimers: enableTimers, serveStaticFiles: serveStaticFiles)
+        )
+    }
+
+    // MARK: - Validation
+
+    private static func validate(_ config: HeliosConfig, env: AppEnv) throws {
+        var errors: [String] = []
+
+        // Required fields
+        if config.mysql.host.isEmpty { errors.append("mysql.host is required") }
+        if config.mysql.username.isEmpty { errors.append("mysql.username is required") }
+        if config.mysql.database.isEmpty { errors.append("mysql.database is required") }
+
+        // Port ranges
+        if config.server.port < 1 || config.server.port > 65535 {
+            errors.append("server.port must be 1–65535 (got \(config.server.port))")
+        }
+        if config.mysql.port < 1 || config.mysql.port > 65535 {
+            errors.append("mysql.port must be 1–65535 (got \(config.mysql.port))")
+        }
+        if config.redis.port < 1 || config.redis.port > 65535 {
+            errors.append("redis.port must be 1–65535 (got \(config.redis.port))")
+        }
+
+        // Production safety
+        if env == .production {
+            if config.features.autoMigrate {
+                errors.append("features.autoMigrate must not be true in production")
+            }
+            if config.mysql.tls == .disable {
+                errors.append("mysql.tls should not be 'disable' in production (set to 'require' or remove to use default)")
+            }
+        }
+
+        guard errors.isEmpty else {
+            throw HeliosConfigError.validationFailed(errors)
+        }
+    }
+
+    // MARK: - Value Converters
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let value else { return nil }
+        if let str = value as? String { return str.isEmpty ? nil : str }
+        return String(describing: value)
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        guard let value else { return nil }
+        if let int = value as? Int { return int }
+        if let double = value as? Double { return Int(double) }
+        if let str = value as? String { return Int(str) }
+        return nil
+    }
+
+    private static func boolValue(_ value: Any?) -> Bool? {
+        guard let value else { return nil }
+        if let bool = value as? Bool { return bool }
+        if let int = value as? Int { return int != 0 }
+        if let str = value as? String {
+            switch str.lowercased() {
+            case "true", "1", "yes": return true
+            case "false", "0", "no": return false
+            default: return nil
+            }
+        }
+        return nil
+    }
+}
+
+// MARK: - Errors
+
+public enum HeliosConfigError: Error, CustomStringConvertible {
+    case invalidFormat(String)
+    case validationFailed([String])
+
+    public var description: String {
+        switch self {
+        case .invalidFormat(let file):
+            return "Helios config error: '\(file)' is not a valid JSON object"
+        case .validationFailed(let errors):
+            return "Helios config validation failed:\n" + errors.map { "  • \($0)" }.joined(separator: "\n")
+        }
+    }
+}

--- a/Tests/HeliosTests/ConfigTests.swift
+++ b/Tests/HeliosTests/ConfigTests.swift
@@ -1,0 +1,218 @@
+//
+//  ConfigTests.swift
+//  HeliosTests
+//
+//  Tests for HeliosConfig, HeliosConfigLoader, and validation logic.
+//
+
+import XCTest
+@testable import Helios
+
+final class ConfigTests: XCTestCase {
+
+    // MARK: - Typed Config Model
+
+    func testDefaultServerConfig() {
+        let server = ServerConfig()
+        XCTAssertEqual(server.host, "0.0.0.0")
+        XCTAssertEqual(server.port, 8080)
+    }
+
+    func testDefaultFeatureFlags() {
+        let flags = FeatureFlags()
+        XCTAssertFalse(flags.autoMigrate)
+        XCTAssertTrue(flags.serveLeaf)
+        XCTAssertTrue(flags.enableQueues)
+        XCTAssertTrue(flags.enableTimers)
+        XCTAssertTrue(flags.serveStaticFiles)
+    }
+
+    func testTLSModeRoundTrip() {
+        XCTAssertEqual(TLSMode(rawValue: "disable"), .disable)
+        XCTAssertEqual(TLSMode(rawValue: "require"), .require)
+        XCTAssertNil(TLSMode(rawValue: "invalid"))
+    }
+
+    func testAppEnvDetectDefaults() {
+        // Without HELIOS_ENV set, should default to development
+        // (env may be set in CI, so we just test parsing)
+        XCTAssertEqual(AppEnv(rawValue: "development"), .development)
+        XCTAssertEqual(AppEnv(rawValue: "production"), .production)
+        XCTAssertEqual(AppEnv(rawValue: "testing"), .testing)
+    }
+
+    // MARK: - Config Loader (from temp files)
+
+    func testLoadBaseConfig() throws {
+        let dir = try makeTempConfigDir(files: [
+            "base.json": """
+            {
+                "server": { "host": "localhost", "port": 3000 },
+                "mysql": { "host": "db.local", "port": 3306, "username": "root", "password": "secret", "database": "helios_dev" },
+                "redis": { "host": "redis.local", "port": 6380 }
+            }
+            """
+        ])
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let config = try HeliosConfigLoader.load(configDir: dir)
+        XCTAssertEqual(config.server.host, "localhost")
+        XCTAssertEqual(config.server.port, 3000)
+        XCTAssertEqual(config.mysql.host, "db.local")
+        XCTAssertEqual(config.mysql.port, 3306)
+        XCTAssertEqual(config.mysql.username, "root")
+        XCTAssertEqual(config.mysql.password, "secret")
+        XCTAssertEqual(config.mysql.database, "helios_dev")
+        XCTAssertEqual(config.redis.host, "redis.local")
+        XCTAssertEqual(config.redis.port, 6380)
+    }
+
+    func testLegacyConfigJsonFallback() throws {
+        let dir = try makeTempConfigDir(files: [
+            "config.json": """
+            {
+                "hostname": "legacy-host",
+                "port": "9090",
+                "mysql_host": "legacy-db",
+                "mysql_port": "3307",
+                "mysql_username": "admin",
+                "mysql_password": "pw",
+                "mysql_database": "legacy_db",
+                "redis_host": "legacy-redis",
+                "redis_port": "6381"
+            }
+            """
+        ])
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let config = try HeliosConfigLoader.load(configDir: dir)
+        XCTAssertEqual(config.server.host, "legacy-host")
+        XCTAssertEqual(config.server.port, 9090)
+        XCTAssertEqual(config.mysql.host, "legacy-db")
+        XCTAssertEqual(config.mysql.database, "legacy_db")
+        XCTAssertEqual(config.redis.host, "legacy-redis")
+        XCTAssertEqual(config.redis.port, 6381)
+    }
+
+    func testEnvOverrideMergesOntoBase() throws {
+        let dir = try makeTempConfigDir(files: [
+            "base.json": """
+            {
+                "server": { "host": "0.0.0.0", "port": 8080 },
+                "mysql": { "host": "localhost", "username": "dev", "password": "dev", "database": "helios" },
+                "redis": { "host": "127.0.0.1" }
+            }
+            """,
+            "development.json": """
+            {
+                "server": { "port": 3000 },
+                "mysql": { "password": "dev-override" }
+            }
+            """
+        ])
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let config = try HeliosConfigLoader.load(configDir: dir)
+        // Overridden
+        XCTAssertEqual(config.server.port, 3000)
+        XCTAssertEqual(config.mysql.password, "dev-override")
+        // Not overridden — kept from base
+        XCTAssertEqual(config.server.host, "0.0.0.0")
+        XCTAssertEqual(config.mysql.host, "localhost")
+        XCTAssertEqual(config.mysql.username, "dev")
+    }
+
+    func testFeatureFlagsFromConfig() throws {
+        let dir = try makeTempConfigDir(files: [
+            "base.json": """
+            {
+                "mysql": { "host": "db", "username": "u", "password": "p", "database": "d" },
+                "features": { "autoMigrate": true, "serveLeaf": false, "enableQueues": false }
+            }
+            """
+        ])
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let config = try HeliosConfigLoader.load(configDir: dir)
+        XCTAssertTrue(config.features.autoMigrate)
+        XCTAssertFalse(config.features.serveLeaf)
+        XCTAssertFalse(config.features.enableQueues)
+        // Defaults for unspecified flags
+        XCTAssertTrue(config.features.enableTimers)
+        XCTAssertTrue(config.features.serveStaticFiles)
+    }
+
+    // MARK: - Validation
+
+    func testValidationFailsOnMissingMySQLHost() throws {
+        let dir = try makeTempConfigDir(files: [
+            "base.json": """
+            {
+                "mysql": { "username": "u", "password": "p", "database": "d" }
+            }
+            """
+        ])
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        XCTAssertThrowsError(try HeliosConfigLoader.load(configDir: dir)) { error in
+            let desc = String(describing: error)
+            XCTAssertTrue(desc.contains("mysql.host"), "Expected mysql.host error, got: \(desc)")
+        }
+    }
+
+    func testValidationFailsOnInvalidPort() throws {
+        let dir = try makeTempConfigDir(files: [
+            "base.json": """
+            {
+                "server": { "port": 99999 },
+                "mysql": { "host": "db", "username": "u", "password": "p", "database": "d" }
+            }
+            """
+        ])
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        XCTAssertThrowsError(try HeliosConfigLoader.load(configDir: dir)) { error in
+            let desc = String(describing: error)
+            XCTAssertTrue(desc.contains("server.port"), "Expected port error, got: \(desc)")
+        }
+    }
+
+    func testValidationFailsOnNoConfigFile() throws {
+        let dir = NSTemporaryDirectory() + "helios-test-empty-\(UUID().uuidString)/"
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        // No config files at all — should still produce a config (all defaults)
+        // but fail validation because mysql.host is empty
+        XCTAssertThrowsError(try HeliosConfigLoader.load(configDir: dir)) { error in
+            let desc = String(describing: error)
+            XCTAssertTrue(desc.contains("mysql.host"), "Expected mysql.host error, got: \(desc)")
+        }
+    }
+
+    // MARK: - HeliosAppConfig facade
+
+    func testAppConfigTestInitializer() {
+        let config = HeliosConfig(
+            server: ServerConfig(host: "test", port: 1234),
+            mysql: MySQLConfig(host: "db", username: "u", password: "p", database: "d"),
+            redis: RedisConfig(),
+            features: FeatureFlags()
+        )
+        let appConfig = HeliosAppConfig(workspacePath: "/tmp/test/", config: config)
+        XCTAssertEqual(appConfig.typed.server.host, "test")
+        XCTAssertEqual(appConfig.typed.server.port, 1234)
+        XCTAssertEqual(appConfig.workspacePath, "/tmp/test/")
+    }
+
+    // MARK: - Helpers
+
+    private func makeTempConfigDir(files: [String: String]) throws -> String {
+        let dir = NSTemporaryDirectory() + "helios-test-\(UUID().uuidString)/"
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        for (name, content) in files {
+            try content.write(toFile: dir + name, atomically: true, encoding: .utf8)
+        }
+        return dir
+    }
+}


### PR DESCRIPTION
## Summary

实现 #3：配置系统重构。把 `[String: String]` + `@dynamicMemberLookup` 升级为 typed config + 三层加载 + 启动校验。

### 新增文件

| 文件 | 说明 |
|------|------|
| `HeliosConfig.swift` | Typed config model：`ServerConfig`、`MySQLConfig`、`RedisConfig`、`FeatureFlags`、`TLSMode`、`AppEnv` |
| `HeliosConfigLoader.swift` | 三层加载（base.json → \<env\>.json → env vars）+ `validate()` |
| `HeliosRouteRegistrar.swift` | 共享路由/filter 注册逻辑（同时包含 PR #10 的改动） |
| `ConfigTests.swift` | 12 个测试：加载、合并、legacy fallback、校验、feature flags |
| `Config/base.example.json` | dev 示例配置 |
| `Config/production.example.json` | prod 示例配置（override only） |

### 改造文件

| 文件 | 改动 |
|------|------|
| `HeliosAppConfig.swift` | 从字符串读取器改为 typed config facade（`.typed` 属性） |
| `HeliosApp.swift` | `setup()` 和 `run()` 全部使用 typed config；feature flags 控制 Leaf/Queues/Timers/Static Files/AutoMigrate |

### 关键决策

1. **`autoMigrate` 默认 false**（原来是隐式 true）
2. **TLS mode 显式**：`disable` / `require`；production 环境下 `tls=disable` 会 fail-fast
3. **env var 白名单**：只认 `HELIOS_*` 前缀的 11 个 key，不做自动映射
4. **Legacy `config.json` 兼容**：如果没有 `base.json`，自动 fallback 到 `config.json`，支持旧的 flat key 格式
5. **Feature flags**：`serveLeaf`、`enableQueues`、`enableTimers`、`serveStaticFiles` 都变成显式开关
6. **Validation**：必填字段检查 + 端口范围 + production 安全校验

### 验证

```
Executed 25 tests, with 0 failures (0 unexpected) in 0.074 seconds
```

✅ Mac devbox `swift test` 全部通过。

### 后续

- Blog 那边需要跟进更新：`config.json` 的引用要换成 `config.typed.xxx`（或直接迁移到 `base.json` 格式）
- PR #10 的内容已包含在本 PR 中（`HeliosRouteRegistrar`），merge 本 PR 后 #10 可以关闭

@jarvis-elevated 请帮忙 review。

Closes #3