### PR TITLE
refactor: decompose setup() into phased bootstrap stages

### DIFF
--- a/Sources/Helios/App/HeliosApp.swift
+++ b/Sources/Helios/App/HeliosApp.swift
@@ -34,14 +34,33 @@ public final class HeliosApp {
         self.delegate = delegate
     }
 
-    private func setup() throws {
-        let c = config.typed
+    // MARK: - Setup Orchestration
 
-        // Server
+    private func setup() throws {
+        try configureServer()
+        try configureStorage()
+        configureViews()
+        configureMiddleware()
+        registerRoutes()
+        registerBackgroundJobs()
+    }
+
+    // MARK: - Phase 1: Server
+
+    /// Configure HTTP server host and port.
+    private func configureServer() throws {
+        let c = config.typed
         app.http.server.configuration.hostname = c.server.host
         app.http.server.configuration.port = c.server.port
+    }
 
-        // Database
+    // MARK: - Phase 2: Storage (MySQL + Redis + Queues driver)
+
+    /// Configure database, Redis, and queue driver connections.
+    private func configureStorage() throws {
+        let c = config.typed
+
+        // MySQL
         var tlsConfig = TLSConfiguration.makeClientConfiguration()
         switch c.mysql.tls {
         case .disable:
@@ -61,7 +80,7 @@ public final class HeliosApp {
             as: .mysql
         )
 
-        // Redis / Queues
+        // Redis
         let redisConfiguration = try RedisConfiguration(
             hostname: c.redis.host,
             port: c.redis.port,
@@ -69,51 +88,70 @@ public final class HeliosApp {
         )
         app.redis.configuration = redisConfiguration
 
+        // Queues driver (only if enabled)
         if c.features.enableQueues {
             app.queues.use(.redis(redisConfiguration))
         }
 
-        // Routes
-        HeliosRouteRegistrar.registerRoutes(delegate.routes(app: self), on: app)
-
         // Model / Migration
-        delegate.models(app: self).forEach { builder in
-            let model = builder()
-            app.migrations.add(model)
-        }
+        HeliosModelRegistrar.register(delegate.models(app: self), on: app)
+    }
 
-        // Views
+    // MARK: - Phase 3: Views & Static Files
+
+    /// Configure Leaf template engine and static file serving.
+    private func configureViews() {
+        let c = config.typed
+
         if c.features.serveLeaf {
             app.views.use(.leaf)
         }
 
-        // Filter / Middleware
-        HeliosRouteRegistrar.registerFilters(delegate.filters(app: self), on: app)
-
         if c.features.serveStaticFiles {
             app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
         }
+    }
 
-        // Timer — only when queues are enabled
-        if c.features.enableQueues && c.features.enableTimers {
+    // MARK: - Phase 4: Middleware (Filters)
+
+    /// Register application-level middleware / filters from the delegate.
+    private func configureMiddleware() {
+        HeliosRouteRegistrar.registerFilters(delegate.filters(app: self), on: app)
+    }
+
+    // MARK: - Phase 5: Routes
+
+    /// Register HTTP route handlers from the delegate.
+    private func registerRoutes() {
+        HeliosRouteRegistrar.registerRoutes(delegate.routes(app: self), on: app)
+    }
+
+    // MARK: - Phase 6: Background Jobs (Timers + Tasks)
+
+    /// Register scheduled timers and async tasks. Only active when queues are enabled.
+    private func registerBackgroundJobs() {
+        let c = config.typed
+        guard c.features.enableQueues else { return }
+
+        if c.features.enableTimers {
             delegate.timers(app: self).forEach { builder in
                 let timer = builder()
                 timer.schedule(queue: app.queues)
             }
         }
 
-        // Task — only when queues are enabled
-        if c.features.enableQueues {
-            delegate.tasks(app: self).forEach { builder in
-                guard let task = builder() as? any HeliosTask else {
-                    app.logger.critical("Unrecognized task builder: \(String(describing: builder))")
-                    return
-                }
-                task.register(queue: app.queues)
+        delegate.tasks(app: self).forEach { builder in
+            guard let task = builder() as? any HeliosTask else {
+                app.logger.critical("Unrecognized task builder: \(String(describing: builder))")
+                return
             }
+            task.register(queue: app.queues)
         }
     }
 
+    // MARK: - Run
+
+    /// Start the application: run migrations (if enabled), start jobs, then serve.
     public func run() throws {
         let c = config.typed
         if c.features.autoMigrate {
@@ -130,6 +168,8 @@ public final class HeliosApp {
         app.shutdown()
     }
 }
+
+// MARK: - Factory
 
 extension HeliosApp {
 

--- a/Sources/Helios/App/HeliosModelRegistrar.swift
+++ b/Sources/Helios/App/HeliosModelRegistrar.swift
@@ -1,0 +1,21 @@
+//
+//  HeliosModelRegistrar.swift
+//  Helios
+//
+//  Shared model/migration registration logic.
+//
+
+import Foundation
+import Vapor
+import Fluent
+
+public enum HeliosModelRegistrar {
+
+    /// Register database models (migrations) on a Vapor `Application`.
+    public static func register(_ builders: [HeliosAnyModelBuilder], on app: Application) {
+        builders.forEach { builder in
+            let model = builder()
+            app.migrations.add(model)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

实现 #4：将 `HeliosApp.setup()` 拆成 6 个阶段函数。

> ⚠️ 本 PR 基于 `feature/typed-config`（PR #12）。需要 #12 先 merge 后再合并本 PR，或者把 base 改为 feature/typed-config。

### 6 个阶段

```swift
func setup() throws {
    try configureServer()       // Phase 1: HTTP host/port
    try configureStorage()      // Phase 2: MySQL + Redis + Queues driver + Migrations
    configureViews()            // Phase 3: Leaf + static files
    configureMiddleware()       // Phase 4: Filters from delegate
    registerRoutes()            // Phase 5: HTTP handlers
    registerBackgroundJobs()    // Phase 6: Timers + Tasks (gated by enableQueues)
}
```

### 边界

| 阶段 | 负责 | 不负责 |
|------|------|--------|
| configureServer | host, port | DB, Redis |
| configureStorage | MySQL, Redis, Queues driver, Migrations | Routes, Middleware |
| configureViews | Leaf, FileMiddleware | API routes |
| configureMiddleware | Delegate filters | Route handlers |
| registerRoutes | Delegate handlers | Background jobs |
| registerBackgroundJobs | Timers, Tasks | Storage init |

### 新增文件

- `HeliosModelRegistrar.swift`：提取 model/migration 注册逻辑

### 验证

```
Executed 25 tests, with 0 failures (0 unexpected)
```

@jarvis-elevated 请帮忙 review。

Closes #4