### PR TITLE
feat: context-aware Task / Timer construction

### DIFF
--- a/Sources/Helios/App/HeliosApp.swift
+++ b/Sources/Helios/App/HeliosApp.swift
@@ -133,15 +133,18 @@ public final class HeliosApp {
         let c = config.typed
         guard c.features.enableQueues else { return }
 
+        let timerContext = HeliosTimerContext(app: self, queues: app.queues)
+        let taskContext = HeliosTaskContext(app: self, queues: app.queues)
+
         if c.features.enableTimers {
             delegate.timers(app: self).forEach { builder in
-                let timer = builder()
+                let timer = builder(timerContext)
                 timer.schedule(queue: app.queues)
             }
         }
 
         delegate.tasks(app: self).forEach { builder in
-            guard let task = builder() as? any HeliosTask else {
+            guard let task = builder(taskContext) as? any HeliosTask else {
                 app.logger.critical("Unrecognized task builder: \(String(describing: builder))")
                 return
             }

--- a/Sources/Helios/Plugins/HeliosContext.swift
+++ b/Sources/Helios/Plugins/HeliosContext.swift
@@ -1,0 +1,33 @@
+//
+//  HeliosContext.swift
+//  Helios
+//
+//  Context structs passed to Task / Timer during construction,
+//  so they can access app-level dependencies at init time.
+//
+
+import Foundation
+import Vapor
+import Queues
+
+/// Context provided to `HeliosTask` at construction time.
+public struct HeliosTaskContext {
+    public let app: HeliosApp
+    public let queues: Application.Queues
+
+    public init(app: HeliosApp, queues: Application.Queues) {
+        self.app = app
+        self.queues = queues
+    }
+}
+
+/// Context provided to `HeliosTimer` at construction time.
+public struct HeliosTimerContext {
+    public let app: HeliosApp
+    public let queues: Application.Queues
+
+    public init(app: HeliosApp, queues: Application.Queues) {
+        self.app = app
+        self.queues = queues
+    }
+}

--- a/Sources/Helios/Plugins/HeliosTask.swift
+++ b/Sources/Helios/Plugins/HeliosTask.swift
@@ -10,21 +10,34 @@ import Vapor
 import Queues
 
 public typealias HeliosAnyTask = AnyJob
-public typealias HeliosAnyTaskBuilder = () -> HeliosAnyTask
+
+/// Builder that receives a `HeliosTaskContext` and returns a configured task.
+/// **Breaking change from v0:** previously `() -> HeliosAnyTask`.
+public typealias HeliosAnyTaskBuilder = (HeliosTaskContext) -> HeliosAnyTask
 
 public protocol HeliosTask: AsyncJob {
 
+    /// Legacy no-arg constructor. Still required for backward compat default impl.
     init()
 
-    func register(queue: Application.Queues)
+    /// Context-aware constructor. Override this to access app-level dependencies at init time.
+    init(context: HeliosTaskContext)
 
+    func register(queue: Application.Queues)
 }
 
 public extension HeliosTask {
 
+    /// Default: context-aware init falls back to no-arg init.
+    /// Existing tasks that only implement `init()` continue to work.
+    init(context: HeliosTaskContext) {
+        self.init()
+    }
+
+    /// Context-aware builder. Passes context through to `init(context:)`.
     static var builder: HeliosAnyTaskBuilder {
-        return {
-            Self.init()
+        return { context in
+            Self.init(context: context)
         }
     }
 
@@ -32,4 +45,3 @@ public extension HeliosTask {
         queue.add(self)
     }
 }
-

--- a/Sources/Helios/Plugins/HeliosTimer.swift
+++ b/Sources/Helios/Plugins/HeliosTimer.swift
@@ -9,21 +9,33 @@ import Foundation
 import Vapor
 import Queues
 
-public typealias HeliosTimerBuilder = () -> HeliosTimer
+/// Builder that receives a `HeliosTimerContext` and returns a configured timer.
+/// **Breaking change from v0:** previously `() -> HeliosTimer`.
+public typealias HeliosTimerBuilder = (HeliosTimerContext) -> HeliosTimer
 
 public protocol HeliosTimer: AsyncScheduledJob {
 
+    /// Legacy no-arg constructor. Still required for backward compat default impl.
     init()
 
-    func schedule(queue: Application.Queues)
+    /// Context-aware constructor. Override this to access app-level dependencies at init time.
+    init(context: HeliosTimerContext)
 
+    func schedule(queue: Application.Queues)
 }
 
 public extension HeliosTimer {
 
+    /// Default: context-aware init falls back to no-arg init.
+    /// Existing timers that only implement `init()` continue to work.
+    init(context: HeliosTimerContext) {
+        self.init()
+    }
+
+    /// Context-aware builder. Passes context through to `init(context:)`.
     static var builder: HeliosTimerBuilder {
-        return {
-            Self.init()
+        return { context in
+            Self.init(context: context)
         }
     }
 }

--- a/Tests/HeliosTests/ContextAwareTests.swift
+++ b/Tests/HeliosTests/ContextAwareTests.swift
@@ -1,0 +1,148 @@
+//
+//  ContextAwareTests.swift
+//  HeliosTests
+//
+//  Tests for context-aware Task / Timer construction (#14).
+//
+
+import XCTest
+import XCTVapor
+import Vapor
+import Queues
+@testable import Helios
+
+final class ContextAwareTests: XCTestCase {
+
+    // MARK: - Context structs
+
+    func testTaskContextHoldsReferences() {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let config = HeliosConfig(
+            server: ServerConfig(),
+            mysql: MySQLConfig(host: "test", username: "u", password: "p", database: "d"),
+            redis: RedisConfig(),
+            features: FeatureFlags()
+        )
+        let appConfig = HeliosAppConfig(workspacePath: "/tmp/test/", config: config)
+        let delegate = TestDelegate()
+        let heliosApp = HeliosApp(app: app, config: appConfig, delegate: delegate)
+
+        let taskCtx = HeliosTaskContext(app: heliosApp, queues: app.queues)
+        let timerCtx = HeliosTimerContext(app: heliosApp, queues: app.queues)
+
+        XCTAssertNotNil(taskCtx.app)
+        XCTAssertNotNil(timerCtx.app)
+    }
+
+    // MARK: - Legacy init() still works via default implementation
+
+    func testLegacyTimerBuilderStillWorks() {
+        // LegacyTimer only implements init(), not init(context:)
+        // The default extension should make builder work via fallback
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let config = HeliosConfig(
+            server: ServerConfig(),
+            mysql: MySQLConfig(host: "test", username: "u", password: "p", database: "d"),
+            redis: RedisConfig(),
+            features: FeatureFlags()
+        )
+        let appConfig = HeliosAppConfig(workspacePath: "/tmp/test/", config: config)
+        let delegate = TestDelegate()
+        let heliosApp = HeliosApp(app: app, config: appConfig, delegate: delegate)
+
+        let ctx = HeliosTimerContext(app: heliosApp, queues: app.queues)
+        let timer = LegacyTimer.builder(ctx)
+        XCTAssertNotNil(timer)
+        XCTAssertTrue(timer is LegacyTimer)
+    }
+
+    func testLegacyTaskBuilderStillWorks() {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let config = HeliosConfig(
+            server: ServerConfig(),
+            mysql: MySQLConfig(host: "test", username: "u", password: "p", database: "d"),
+            redis: RedisConfig(),
+            features: FeatureFlags()
+        )
+        let appConfig = HeliosAppConfig(workspacePath: "/tmp/test/", config: config)
+        let delegate = TestDelegate()
+        let heliosApp = HeliosApp(app: app, config: appConfig, delegate: delegate)
+
+        let ctx = HeliosTaskContext(app: heliosApp, queues: app.queues)
+        let task = LegacyTask.builder(ctx)
+        XCTAssertNotNil(task)
+    }
+
+    // MARK: - Context-aware init receives context
+
+    func testContextAwareTimerReceivesContext() {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let config = HeliosConfig(
+            server: ServerConfig(host: "ctx-test", port: 9999),
+            mysql: MySQLConfig(host: "test", username: "u", password: "p", database: "d"),
+            redis: RedisConfig(),
+            features: FeatureFlags()
+        )
+        let appConfig = HeliosAppConfig(workspacePath: "/tmp/test/", config: config)
+        let delegate = TestDelegate()
+        let heliosApp = HeliosApp(app: app, config: appConfig, delegate: delegate)
+
+        let ctx = HeliosTimerContext(app: heliosApp, queues: app.queues)
+        let timer = ContextAwareTimer.builder(ctx) as! ContextAwareTimer
+        XCTAssertEqual(timer.serverHost, "ctx-test")
+    }
+}
+
+// MARK: - Test Fixtures
+
+/// A timer that only implements `init()` — simulates existing downstream timers.
+private final class LegacyTimer: HeliosTimer {
+    required init() {}
+
+    func schedule(queue: Application.Queues) {
+        // no-op for test
+    }
+
+    func run(context: QueueContext) async throws {
+        // no-op
+    }
+}
+
+/// A task that only implements `init()`.
+private struct LegacyTask: HeliosTask {
+    typealias Payload = String
+    init() {}
+
+    func dequeue(_ context: QueueContext, _ payload: String) async throws {
+        // no-op
+    }
+}
+
+/// A timer that uses `init(context:)` to capture app-level config.
+private final class ContextAwareTimer: HeliosTimer {
+    let serverHost: String
+
+    required init() {
+        self.serverHost = ""
+    }
+
+    required init(context: HeliosTimerContext) {
+        self.serverHost = context.app.config.typed.server.host
+    }
+
+    func schedule(queue: Application.Queues) {
+        // no-op
+    }
+
+    func run(context: QueueContext) async throws {
+        // no-op
+    }
+}


### PR DESCRIPTION
## Summary

实现 #14：为 Task / Timer 引入 context-aware 构造能力。

### Changes

| 文件 | 说明 |
|------|------|
| **新增** `HeliosContext.swift` | `HeliosTaskContext` + `HeliosTimerContext` structs |
| **新增** `ContextAwareTests.swift` | 4 个测试 |
| **改造** `HeliosTask.swift` | builder 改为 `(HeliosTaskContext) -> HeliosAnyTask`；新增 `init(context:)` |
| **改造** `HeliosTimer.swift` | builder 改为 `(HeliosTimerContext) -> HeliosTimer`；新增 `init(context:)` |
| **改造** `HeliosApp.swift` | `registerBackgroundJobs()` 构造 context 并传入 builder |

### 兼容策略

- 现有 Task/Timer 只实现 `init()` 的仍然可以工作（`init(context:)` 默认 fallback 到 `init()`）
- 新的 Task/Timer 可以 override `init(context:)` 来在构造阶段拿到 `app` / `queues`

### ⚠️ Breaking Changes

按讨论结论，直接改 builder 签名：
- `HeliosAnyTaskBuilder`：`() -> HeliosAnyTask` → `(HeliosTaskContext) -> HeliosAnyTask`
- `HeliosTimerBuilder`：`() -> HeliosTimer` → `(HeliosTimerContext) -> HeliosTimer`

下游（Blog）需要同步更新 delegate 中的 timer/task builder 引用。编译器会精确标出需要修改的位置。

### 验证

```
Executed 29 tests, with 0 failures (0 unexpected)
```

@jarvis-elevated 请帮忙 review。

Closes #14