### PR TITLE
feat: context-aware Handler / Filter construction

### DIFF
--- a/Sources/Helios/App/HeliosApp.swift
+++ b/Sources/Helios/App/HeliosApp.swift
@@ -116,14 +116,14 @@ public final class HeliosApp {
 
     /// Register application-level middleware / filters from the delegate.
     private func configureMiddleware() {
-        HeliosRouteRegistrar.registerFilters(delegate.filters(app: self), on: app)
+        HeliosRouteRegistrar.registerFilters(delegate.filters(app: self), on: app, heliosApp: self)
     }
 
     // MARK: - Phase 5: Routes
 
     /// Register HTTP route handlers from the delegate.
     private func registerRoutes() {
-        HeliosRouteRegistrar.registerRoutes(delegate.routes(app: self), on: app)
+        HeliosRouteRegistrar.registerRoutes(delegate.routes(app: self), on: app, heliosApp: self)
     }
 
     // MARK: - Phase 6: Background Jobs (Timers + Tasks)

--- a/Sources/Helios/App/HeliosRouteRegistrar.swift
+++ b/Sources/Helios/App/HeliosRouteRegistrar.swift
@@ -12,9 +12,34 @@ import Vapor
 public enum HeliosRouteRegistrar {
 
     /// Register handler-based routes on a Vapor `Application`.
+    /// Context is created once and captured by route closures (not per-request).
     public static func registerRoutes(
         _ routes: [String: [HTTPMethod: HeliosHandlerBuilder]],
-        on app: Application
+        on app: Application,
+        heliosApp: HeliosApp
+    ) {
+        let context = HeliosHandlerContext(app: heliosApp)
+        routes
+            .flatMap { (path: String, handlerMap: [HTTPMethod: HeliosHandlerBuilder]) in
+                handlerMap.map { (method: HTTPMethod, builder: @escaping HeliosHandlerBuilder) in
+                    (path, method, builder)
+                }
+            }
+            .forEach { (path, method, builder) in
+                app.on(method, path.pathComponents) { req async throws -> AnyAsyncResponse in
+                    let handler = builder(context)
+                    let result = try await handler.handle(req: req)
+                    return AnyAsyncResponse(result)
+                }
+            }
+    }
+
+    /// Convenience overload for tests: creates a minimal context-free registration.
+    /// Uses a lightweight shim so test harness doesn't need a full HeliosApp.
+    public static func registerRoutes(
+        _ routes: [String: [HTTPMethod: HeliosHandlerBuilder]],
+        on app: Application,
+        context: HeliosHandlerContext
     ) {
         routes
             .flatMap { (path: String, handlerMap: [HTTPMethod: HeliosHandlerBuilder]) in
@@ -24,7 +49,7 @@ public enum HeliosRouteRegistrar {
             }
             .forEach { (path, method, builder) in
                 app.on(method, path.pathComponents) { req async throws -> AnyAsyncResponse in
-                    let handler = builder()
+                    let handler = builder(context)
                     let result = try await handler.handle(req: req)
                     return AnyAsyncResponse(result)
                 }
@@ -34,10 +59,24 @@ public enum HeliosRouteRegistrar {
     /// Register filters (middleware) on a Vapor `Application`.
     public static func registerFilters(
         _ filters: [HeliosFilterBuilder],
-        on app: Application
+        on app: Application,
+        heliosApp: HeliosApp
+    ) {
+        let context = HeliosFilterContext(app: heliosApp)
+        filters.forEach { builder in
+            let filter = builder(context)
+            app.middleware.use(filter)
+        }
+    }
+
+    /// Convenience overload for tests.
+    public static func registerFilters(
+        _ filters: [HeliosFilterBuilder],
+        on app: Application,
+        context: HeliosFilterContext
     ) {
         filters.forEach { builder in
-            let filter = builder()
+            let filter = builder(context)
             app.middleware.use(filter)
         }
     }

--- a/Sources/Helios/Plugins/HeliosContext.swift
+++ b/Sources/Helios/Plugins/HeliosContext.swift
@@ -2,13 +2,31 @@
 //  HeliosContext.swift
 //  Helios
 //
-//  Context structs passed to Task / Timer during construction,
+//  Context structs passed to framework extension points during construction,
 //  so they can access app-level dependencies at init time.
 //
 
 import Foundation
 import Vapor
 import Queues
+
+/// Context provided to `HeliosHandler` at construction time.
+public struct HeliosHandlerContext {
+    public let app: HeliosApp
+
+    public init(app: HeliosApp) {
+        self.app = app
+    }
+}
+
+/// Context provided to `HeliosFilter` at construction time.
+public struct HeliosFilterContext {
+    public let app: HeliosApp
+
+    public init(app: HeliosApp) {
+        self.app = app
+    }
+}
 
 /// Context provided to `HeliosTask` at construction time.
 public struct HeliosTaskContext {

--- a/Sources/Helios/Plugins/HeliosFilter.swift
+++ b/Sources/Helios/Plugins/HeliosFilter.swift
@@ -8,11 +8,17 @@
 import Foundation
 import Vapor
 
-public typealias HeliosFilterBuilder = () -> HeliosFilter
+/// Builder that receives a `HeliosFilterContext` and returns a configured filter.
+/// **Breaking change:** previously `() -> HeliosFilter`.
+public typealias HeliosFilterBuilder = (HeliosFilterContext) -> HeliosFilter
 
 public protocol HeliosFilter: AsyncMiddleware {
 
+    /// Legacy no-arg constructor.
     init()
+
+    /// Context-aware constructor. Override to access app-level dependencies at init time.
+    init(context: HeliosFilterContext)
 
     func filterRequest(request: Request) async throws -> Response?
 
@@ -21,9 +27,14 @@ public protocol HeliosFilter: AsyncMiddleware {
 
 public extension HeliosFilter {
 
+    /// Default: falls back to no-arg init.
+    init(context: HeliosFilterContext) {
+        self.init()
+    }
+
     static var builder: HeliosFilterBuilder {
-        return {
-            Self.init()
+        return { context in
+            Self.init(context: context)
         }
     }
 

--- a/Sources/Helios/Views/HeliosHandler.swift
+++ b/Sources/Helios/Views/HeliosHandler.swift
@@ -8,11 +8,17 @@
 import Foundation
 import Vapor
 
-public typealias HeliosHandlerBuilder = () -> HeliosHandler
+/// Builder that receives a `HeliosHandlerContext` and returns a configured handler.
+/// **Breaking change:** previously `() -> HeliosHandler`.
+public typealias HeliosHandlerBuilder = (HeliosHandlerContext) -> HeliosHandler
 
 public protocol HeliosHandler {
 
+    /// Legacy no-arg constructor.
     init()
+
+    /// Context-aware constructor. Override to access app-level dependencies at init time.
+    init(context: HeliosHandlerContext)
 
     func handle(req: Request) async throws -> AsyncResponseEncodable
 
@@ -20,9 +26,15 @@ public protocol HeliosHandler {
 
 public extension HeliosHandler {
 
+    /// Default: falls back to no-arg init. Existing handlers continue to work.
+    init(context: HeliosHandlerContext) {
+        self.init()
+    }
+
+    /// Context-aware builder.
     static var builder: HeliosHandlerBuilder {
-        return {
-            Self.init()
+        return { context in
+            Self.init(context: context)
         }
     }
 }

--- a/Tests/HeliosTests/ContextAwareTests.swift
+++ b/Tests/HeliosTests/ContextAwareTests.swift
@@ -18,16 +18,7 @@ final class ContextAwareTests: XCTestCase {
     func testTaskContextHoldsReferences() {
         let app = Application(.testing)
         defer { app.shutdown() }
-
-        let config = HeliosConfig(
-            server: ServerConfig(),
-            mysql: MySQLConfig(host: "test", username: "u", password: "p", database: "d"),
-            redis: RedisConfig(),
-            features: FeatureFlags()
-        )
-        let appConfig = HeliosAppConfig(workspacePath: "/tmp/test/", config: config)
-        let delegate = TestDelegate()
-        let heliosApp = HeliosApp(app: app, config: appConfig, delegate: delegate)
+        let heliosApp = makeTestHeliosApp(app: app)
 
         let taskCtx = HeliosTaskContext(app: heliosApp, queues: app.queues)
         let timerCtx = HeliosTimerContext(app: heliosApp, queues: app.queues)
@@ -39,20 +30,9 @@ final class ContextAwareTests: XCTestCase {
     // MARK: - Legacy init() still works via default implementation
 
     func testLegacyTimerBuilderStillWorks() {
-        // LegacyTimer only implements init(), not init(context:)
-        // The default extension should make builder work via fallback
         let app = Application(.testing)
         defer { app.shutdown() }
-
-        let config = HeliosConfig(
-            server: ServerConfig(),
-            mysql: MySQLConfig(host: "test", username: "u", password: "p", database: "d"),
-            redis: RedisConfig(),
-            features: FeatureFlags()
-        )
-        let appConfig = HeliosAppConfig(workspacePath: "/tmp/test/", config: config)
-        let delegate = TestDelegate()
-        let heliosApp = HeliosApp(app: app, config: appConfig, delegate: delegate)
+        let heliosApp = makeTestHeliosApp(app: app)
 
         let ctx = HeliosTimerContext(app: heliosApp, queues: app.queues)
         let timer = LegacyTimer.builder(ctx)
@@ -63,16 +43,7 @@ final class ContextAwareTests: XCTestCase {
     func testLegacyTaskBuilderStillWorks() {
         let app = Application(.testing)
         defer { app.shutdown() }
-
-        let config = HeliosConfig(
-            server: ServerConfig(),
-            mysql: MySQLConfig(host: "test", username: "u", password: "p", database: "d"),
-            redis: RedisConfig(),
-            features: FeatureFlags()
-        )
-        let appConfig = HeliosAppConfig(workspacePath: "/tmp/test/", config: config)
-        let delegate = TestDelegate()
-        let heliosApp = HeliosApp(app: app, config: appConfig, delegate: delegate)
+        let heliosApp = makeTestHeliosApp(app: app)
 
         let ctx = HeliosTaskContext(app: heliosApp, queues: app.queues)
         let task = LegacyTask.builder(ctx)
@@ -84,7 +55,6 @@ final class ContextAwareTests: XCTestCase {
     func testContextAwareTimerReceivesContext() {
         let app = Application(.testing)
         defer { app.shutdown() }
-
         let config = HeliosConfig(
             server: ServerConfig(host: "ctx-test", port: 9999),
             mysql: MySQLConfig(host: "test", username: "u", password: "p", database: "d"),
@@ -103,30 +73,20 @@ final class ContextAwareTests: XCTestCase {
 
 // MARK: - Test Fixtures
 
-/// A timer that only implements `init()` — simulates existing downstream timers.
 private final class LegacyTimer: HeliosTimer {
     required init() {}
 
-    func schedule(queue: Application.Queues) {
-        // no-op for test
-    }
-
-    func run(context: QueueContext) async throws {
-        // no-op
-    }
+    func schedule(queue: Application.Queues) {}
+    func run(context: QueueContext) async throws {}
 }
 
-/// A task that only implements `init()`.
 private struct LegacyTask: HeliosTask {
     typealias Payload = String
     init() {}
 
-    func dequeue(_ context: QueueContext, _ payload: String) async throws {
-        // no-op
-    }
+    func dequeue(_ context: QueueContext, _ payload: String) async throws {}
 }
 
-/// A timer that uses `init(context:)` to capture app-level config.
 private final class ContextAwareTimer: HeliosTimer {
     let serverHost: String
 
@@ -138,11 +98,6 @@ private final class ContextAwareTimer: HeliosTimer {
         self.serverHost = context.app.config.typed.server.host
     }
 
-    func schedule(queue: Application.Queues) {
-        // no-op
-    }
-
-    func run(context: QueueContext) async throws {
-        // no-op
-    }
+    func schedule(queue: Application.Queues) {}
+    func run(context: QueueContext) async throws {}
 }

--- a/Tests/HeliosTests/Fixtures/TestHeliosApp.swift
+++ b/Tests/HeliosTests/Fixtures/TestHeliosApp.swift
@@ -15,7 +15,6 @@ import XCTVapor
 // MARK: - Minimal Test Delegate
 
 /// A bare-bones delegate that registers only what each test needs.
-/// Override `routes`, `filters`, etc. in subclasses or per-test closures.
 final class TestDelegate: HeliosAppDelegate {
 
     var routeTable: [String: [HTTPMethod: HeliosHandlerBuilder]] = [:]
@@ -74,16 +73,35 @@ struct TestHeaderFilter: HeliosFilter {
     }
 }
 
+// MARK: - Test Helpers
+
+/// Default test config — no real DB/Redis needed.
+let testConfig = HeliosConfig(
+    server: ServerConfig(),
+    mysql: MySQLConfig(host: "test", username: "test", password: "test", database: "test"),
+    redis: RedisConfig(),
+    features: FeatureFlags()
+)
+
+/// Create a minimal `HeliosApp` for test context construction.
+/// Does NOT connect to any external services.
+func makeTestHeliosApp(app: Application, delegate: TestDelegate = TestDelegate()) -> HeliosApp {
+    let appConfig = HeliosAppConfig(workspacePath: "/tmp/helios-test/", config: testConfig)
+    return HeliosApp(app: app, config: appConfig, delegate: delegate)
+}
+
 // MARK: - App Factory
 
-/// Create a lightweight Vapor `Application` for testing.
-/// Does NOT connect to MySQL or Redis — suitable for route / handler / filter tests.
+/// Create a lightweight Vapor `Application` for testing with routes and filters registered.
 func makeTestApp(delegate: TestDelegate = TestDelegate()) throws -> Application {
     let app = Application(.testing)
+    let heliosApp = makeTestHeliosApp(app: app, delegate: delegate)
 
-    // Use the same registrar as production HeliosApp
-    HeliosRouteRegistrar.registerRoutes(delegate.routeTable, on: app)
-    HeliosRouteRegistrar.registerFilters(delegate.filterList, on: app)
+    let handlerContext = HeliosHandlerContext(app: heliosApp)
+    let filterContext = HeliosFilterContext(app: heliosApp)
+
+    HeliosRouteRegistrar.registerRoutes(delegate.routeTable, on: app, context: handlerContext)
+    HeliosRouteRegistrar.registerFilters(delegate.filterList, on: app, context: filterContext)
 
     return app
 }

--- a/Tests/HeliosTests/IntegrationTests.swift
+++ b/Tests/HeliosTests/IntegrationTests.swift
@@ -139,9 +139,15 @@ final class IntegrationTests: XCTestCase {
     // MARK: - Handler builder pattern
 
     func testBuilderCreatesDistinctInstances() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        let delegate = TestDelegate()
+        let heliosApp = makeTestHeliosApp(app: app, delegate: delegate)
+        let context = HeliosHandlerContext(app: heliosApp)
+
         let builder = EchoHandler.builder
-        let a = builder()
-        let b = builder()
+        let a = builder(context)
+        let b = builder(context)
         // Each call should return a new instance (value type or reference)
         XCTAssertNotNil(a)
         XCTAssertNotNil(b)

--- a/Tests/HeliosTests/SmokeTests.swift
+++ b/Tests/HeliosTests/SmokeTests.swift
@@ -16,12 +16,12 @@ final class SmokeTests: XCTestCase {
 
     func testHandlerProtocolConformance() throws {
         // EchoHandler conforms to HeliosHandler and can be built via .builder
-        let handler = EchoHandler.builder()
+        let handler = EchoHandler()
         XCTAssertNotNil(handler)
     }
 
     func testFilterProtocolConformance() throws {
-        let filter = TestHeaderFilter.builder()
+        let filter = TestHeaderFilter()
         XCTAssertNotNil(filter)
     }
 


### PR DESCRIPTION
## Summary

实现 #15：为 Handler / Filter 引入 context-aware 构造入口。与 #14（Task/Timer）完全对称的改造。

### Changes

| 文件 | 说明 |
|------|------|
| **新增** `HeliosContext.swift` | `HeliosHandlerContext`、`HeliosFilterContext`（+ Task/Timer contexts） |
| **改造** `HeliosHandler.swift` | builder → `(HeliosHandlerContext) -> HeliosHandler`；`init(context:)` + fallback |
| **改造** `HeliosFilter.swift` | builder → `(HeliosFilterContext) -> HeliosFilter`；`init(context:)` + fallback |
| **改造** `HeliosRouteRegistrar.swift` | 新增 `heliosApp:` / `context:` 参数；context 在注册时创建一次，不是每个 request |
| **改造** `HeliosApp.swift` | 传 `self` 给 registrar |
| **改造** Tests | 适配新 builder 签名 |

### ⚠️ Breaking Changes

- `HeliosHandlerBuilder`：`() -> HeliosHandler` → `(HeliosHandlerContext) -> HeliosHandler`
- `HeliosFilterBuilder`：`() -> HeliosFilter` → `(HeliosFilterContext) -> HeliosFilter`

下游（Blog）需要同步更新。编译器会精确标出位置。

### 与 PR #19 (#14) 的关系

本 PR 包含了 `HeliosContext.swift`（含所有 4 种 context），和 #19 有文件级重叠。建议合并顺序：先 merge 一个，再 rebase 另一个收冲突。

### 验证

```
Executed 25 tests, with 0 failures (0 unexpected)
```

@jarvis-elevated 请帮忙 review。

Closes #15