### PR TITLE
feat: descriptor/provider extension point API (#16)

### DIFF
--- a/Sources/Helios/App/HeliosApp.swift
+++ b/Sources/Helios/App/HeliosApp.swift
@@ -115,20 +115,33 @@ public final class HeliosApp {
     // MARK: - Phase 4: Middleware (Filters)
 
     /// Register application-level middleware / filters from the delegate.
+    /// Descriptor-based API takes priority; falls back to legacy builders.
     private func configureMiddleware() {
-        HeliosRouteRegistrar.registerFilters(delegate.filters(app: self), on: app, heliosApp: self)
+        let descriptors = delegate.filterDescriptors(app: self)
+        if !descriptors.isEmpty {
+            HeliosRouteRegistrar.registerFilters(descriptors, on: app, heliosApp: self)
+        } else {
+            HeliosRouteRegistrar.registerFilters(delegate.filters(app: self), on: app, heliosApp: self)
+        }
     }
 
     // MARK: - Phase 5: Routes
 
     /// Register HTTP route handlers from the delegate.
+    /// Descriptor-based API takes priority; falls back to legacy builders.
     private func registerRoutes() {
-        HeliosRouteRegistrar.registerRoutes(delegate.routes(app: self), on: app, heliosApp: self)
+        let descriptors = delegate.routeDescriptors(app: self)
+        if !descriptors.isEmpty {
+            HeliosRouteRegistrar.registerRoutes(descriptors, on: app, heliosApp: self)
+        } else {
+            HeliosRouteRegistrar.registerRoutes(delegate.routes(app: self), on: app, heliosApp: self)
+        }
     }
 
     // MARK: - Phase 6: Background Jobs (Timers + Tasks)
 
     /// Register scheduled timers and async tasks. Only active when queues are enabled.
+    /// Descriptor-based API takes priority; falls back to legacy builders.
     private func registerBackgroundJobs() {
         let c = config.typed
         guard c.features.enableQueues else { return }
@@ -136,19 +149,40 @@ public final class HeliosApp {
         let timerContext = HeliosTimerContext(app: self, queues: app.queues)
         let taskContext = HeliosTaskContext(app: self, queues: app.queues)
 
+        // Timers: descriptor-first
         if c.features.enableTimers {
-            delegate.timers(app: self).forEach { builder in
-                let timer = builder(timerContext)
-                timer.schedule(queue: app.queues)
+            let timerDescriptors = delegate.timerDescriptors(app: self)
+            if !timerDescriptors.isEmpty {
+                timerDescriptors.forEach { descriptor in
+                    let timer = descriptor.makeTimer(timerContext)
+                    timer.schedule(queue: app.queues)
+                }
+            } else {
+                delegate.timers(app: self).forEach { builder in
+                    let timer = builder(timerContext)
+                    timer.schedule(queue: app.queues)
+                }
             }
         }
 
-        delegate.tasks(app: self).forEach { builder in
-            guard let task = builder(taskContext) as? any HeliosTask else {
-                app.logger.critical("Unrecognized task builder: \(String(describing: builder))")
-                return
+        // Tasks: descriptor-first
+        let taskDescriptors = delegate.taskDescriptors(app: self)
+        if !taskDescriptors.isEmpty {
+            taskDescriptors.forEach { descriptor in
+                guard let task = descriptor.makeTask(taskContext) as? any HeliosTask else {
+                    app.logger.critical("Descriptor '\(descriptor.name)' produced unrecognized task")
+                    return
+                }
+                task.register(queue: app.queues)
             }
-            task.register(queue: app.queues)
+        } else {
+            delegate.tasks(app: self).forEach { builder in
+                guard let task = builder(taskContext) as? any HeliosTask else {
+                    app.logger.critical("Unrecognized task builder: \(String(describing: builder))")
+                    return
+                }
+                task.register(queue: app.queues)
+            }
         }
     }
 

--- a/Sources/Helios/App/HeliosAppDelegate.swift
+++ b/Sources/Helios/App/HeliosAppDelegate.swift
@@ -11,6 +11,8 @@ import Fluent
 
 public protocol HeliosAppDelegate {
 
+    // MARK: - Legacy builder-based API (still supported)
+
     func routes(app: HeliosApp) -> [String: [HTTPMethod: HeliosHandlerBuilder]]
 
     func models(app: HeliosApp) -> [HeliosAnyModelBuilder]
@@ -20,9 +22,24 @@ public protocol HeliosAppDelegate {
     func timers(app: HeliosApp) -> [HeliosTimerBuilder]
 
     func tasks(app: HeliosApp) -> [HeliosAnyTaskBuilder]
+
+    // MARK: - Descriptor-based API (preferred)
+    //
+    // Override these to declare extension points via descriptors.
+    // When non-empty, these take priority over the legacy builder methods.
+
+    func routeDescriptors(app: HeliosApp) -> [HeliosRouteDescriptor]
+
+    func filterDescriptors(app: HeliosApp) -> [HeliosFilterDescriptor]
+
+    func taskDescriptors(app: HeliosApp) -> [HeliosTaskDescriptor]
+
+    func timerDescriptors(app: HeliosApp) -> [HeliosTimerDescriptor]
 }
 
 public extension HeliosAppDelegate {
+
+    // MARK: - Legacy defaults
 
     func routes(app: HeliosApp) -> [String: [HTTPMethod: HeliosHandlerBuilder]] {
         return [:]
@@ -41,6 +58,24 @@ public extension HeliosAppDelegate {
     }
 
     func tasks(app: HeliosApp) -> [HeliosAnyTaskBuilder] {
+        return []
+    }
+
+    // MARK: - Descriptor defaults (empty → fallback to legacy)
+
+    func routeDescriptors(app: HeliosApp) -> [HeliosRouteDescriptor] {
+        return []
+    }
+
+    func filterDescriptors(app: HeliosApp) -> [HeliosFilterDescriptor] {
+        return []
+    }
+
+    func taskDescriptors(app: HeliosApp) -> [HeliosTaskDescriptor] {
+        return []
+    }
+
+    func timerDescriptors(app: HeliosApp) -> [HeliosTimerDescriptor] {
         return []
     }
 }

--- a/Sources/Helios/App/HeliosFilterDescriptor.swift
+++ b/Sources/Helios/App/HeliosFilterDescriptor.swift
@@ -1,0 +1,39 @@
+//
+//  HeliosFilterDescriptor.swift
+//  Helios
+//
+//  Descriptor for filter extension points. Separates declaration metadata
+//  (name) from instance construction (makeFilter).
+//
+
+import Foundation
+import Vapor
+
+/// A filter declaration that pairs an optional name with a context-aware filter factory.
+public struct HeliosFilterDescriptor {
+
+    /// Optional human-readable name for logging / debugging.
+    public let name: String?
+
+    /// Factory that receives a `HeliosFilterContext` and returns a configured filter.
+    public let makeFilter: (HeliosFilterContext) -> HeliosFilter
+
+    public init(
+        name: String? = nil,
+        makeFilter: @escaping (HeliosFilterContext) -> HeliosFilter
+    ) {
+        self.name = name
+        self.makeFilter = makeFilter
+    }
+}
+
+// MARK: - Convenience initializer from HeliosFilter type
+
+extension HeliosFilterDescriptor {
+
+    /// Create a descriptor that uses the filter type's context-aware init.
+    public init<F: HeliosFilter>(name: String? = nil, filter: F.Type) {
+        self.name = name ?? String(describing: F.self)
+        self.makeFilter = { context in F.init(context: context) }
+    }
+}

--- a/Sources/Helios/App/HeliosRouteDescriptor.swift
+++ b/Sources/Helios/App/HeliosRouteDescriptor.swift
@@ -1,0 +1,45 @@
+//
+//  HeliosRouteDescriptor.swift
+//  Helios
+//
+//  Descriptor for route extension points. Separates declaration metadata
+//  (path, method) from instance construction (makeHandler).
+//
+
+import Foundation
+import Vapor
+
+/// A route declaration that pairs HTTP path + method with a context-aware handler factory.
+public struct HeliosRouteDescriptor {
+
+    /// The route path, e.g. `"api/users"`.
+    public let path: String
+
+    /// The HTTP method (GET, POST, …).
+    public let method: HTTPMethod
+
+    /// Factory that receives a `HeliosHandlerContext` and returns a configured handler.
+    public let makeHandler: (HeliosHandlerContext) -> HeliosHandler
+
+    public init(
+        path: String,
+        method: HTTPMethod,
+        makeHandler: @escaping (HeliosHandlerContext) -> HeliosHandler
+    ) {
+        self.path = path
+        self.method = method
+        self.makeHandler = makeHandler
+    }
+}
+
+// MARK: - Convenience initializer from HeliosHandler type
+
+extension HeliosRouteDescriptor {
+
+    /// Create a descriptor that uses the handler type's context-aware init.
+    public init<H: HeliosHandler>(path: String, method: HTTPMethod, handler: H.Type) {
+        self.path = path
+        self.method = method
+        self.makeHandler = { context in H.init(context: context) }
+    }
+}

--- a/Sources/Helios/App/HeliosRouteRegistrar.swift
+++ b/Sources/Helios/App/HeliosRouteRegistrar.swift
@@ -11,6 +11,8 @@ import Vapor
 
 public enum HeliosRouteRegistrar {
 
+    // MARK: - Legacy builder-based registration
+
     /// Register handler-based routes on a Vapor `Application`.
     /// Context is created once and captured by route closures (not per-request).
     public static func registerRoutes(
@@ -19,19 +21,7 @@ public enum HeliosRouteRegistrar {
         heliosApp: HeliosApp
     ) {
         let context = HeliosHandlerContext(app: heliosApp)
-        routes
-            .flatMap { (path: String, handlerMap: [HTTPMethod: HeliosHandlerBuilder]) in
-                handlerMap.map { (method: HTTPMethod, builder: @escaping HeliosHandlerBuilder) in
-                    (path, method, builder)
-                }
-            }
-            .forEach { (path, method, builder) in
-                app.on(method, path.pathComponents) { req async throws -> AnyAsyncResponse in
-                    let handler = builder(context)
-                    let result = try await handler.handle(req: req)
-                    return AnyAsyncResponse(result)
-                }
-            }
+        registerRoutes(routes, on: app, context: context)
     }
 
     /// Convenience overload for tests: creates a minimal context-free registration.
@@ -56,6 +46,35 @@ public enum HeliosRouteRegistrar {
             }
     }
 
+    // MARK: - Descriptor-based registration
+
+    /// Register routes from descriptors. Context is created once and captured.
+    public static func registerRoutes(
+        _ descriptors: [HeliosRouteDescriptor],
+        on app: Application,
+        heliosApp: HeliosApp
+    ) {
+        let context = HeliosHandlerContext(app: heliosApp)
+        registerRoutes(descriptors, on: app, context: context)
+    }
+
+    /// Convenience overload for tests.
+    public static func registerRoutes(
+        _ descriptors: [HeliosRouteDescriptor],
+        on app: Application,
+        context: HeliosHandlerContext
+    ) {
+        descriptors.forEach { descriptor in
+            app.on(descriptor.method, descriptor.path.pathComponents) { req async throws -> AnyAsyncResponse in
+                let handler = descriptor.makeHandler(context)
+                let result = try await handler.handle(req: req)
+                return AnyAsyncResponse(result)
+            }
+        }
+    }
+
+    // MARK: - Legacy filter registration
+
     /// Register filters (middleware) on a Vapor `Application`.
     public static func registerFilters(
         _ filters: [HeliosFilterBuilder],
@@ -63,10 +82,7 @@ public enum HeliosRouteRegistrar {
         heliosApp: HeliosApp
     ) {
         let context = HeliosFilterContext(app: heliosApp)
-        filters.forEach { builder in
-            let filter = builder(context)
-            app.middleware.use(filter)
-        }
+        registerFilters(filters, on: app, context: context)
     }
 
     /// Convenience overload for tests.
@@ -77,6 +93,30 @@ public enum HeliosRouteRegistrar {
     ) {
         filters.forEach { builder in
             let filter = builder(context)
+            app.middleware.use(filter)
+        }
+    }
+
+    // MARK: - Descriptor-based filter registration
+
+    /// Register filters from descriptors. Context is created once and captured.
+    public static func registerFilters(
+        _ descriptors: [HeliosFilterDescriptor],
+        on app: Application,
+        heliosApp: HeliosApp
+    ) {
+        let context = HeliosFilterContext(app: heliosApp)
+        registerFilters(descriptors, on: app, context: context)
+    }
+
+    /// Convenience overload for tests.
+    public static func registerFilters(
+        _ descriptors: [HeliosFilterDescriptor],
+        on app: Application,
+        context: HeliosFilterContext
+    ) {
+        descriptors.forEach { descriptor in
+            let filter = descriptor.makeFilter(context)
             app.middleware.use(filter)
         }
     }

--- a/Sources/Helios/Plugins/HeliosTaskDescriptor.swift
+++ b/Sources/Helios/Plugins/HeliosTaskDescriptor.swift
@@ -1,0 +1,40 @@
+//
+//  HeliosTaskDescriptor.swift
+//  Helios
+//
+//  Descriptor for task extension points. Separates declaration metadata
+//  (name) from instance construction (makeTask).
+//
+
+import Foundation
+import Vapor
+import Queues
+
+/// A task declaration that pairs a name with a context-aware task factory.
+public struct HeliosTaskDescriptor {
+
+    /// Human-readable task name for logging / debugging.
+    public let name: String
+
+    /// Factory that receives a `HeliosTaskContext` and returns a configured task.
+    public let makeTask: (HeliosTaskContext) -> HeliosAnyTask
+
+    public init(
+        name: String,
+        makeTask: @escaping (HeliosTaskContext) -> HeliosAnyTask
+    ) {
+        self.name = name
+        self.makeTask = makeTask
+    }
+}
+
+// MARK: - Convenience initializer from HeliosTask type
+
+extension HeliosTaskDescriptor {
+
+    /// Create a descriptor that uses the task type's context-aware init.
+    public init<T: HeliosTask>(name: String? = nil, task: T.Type) {
+        self.name = name ?? String(describing: T.self)
+        self.makeTask = { context in T.init(context: context) }
+    }
+}

--- a/Sources/Helios/Plugins/HeliosTimerDescriptor.swift
+++ b/Sources/Helios/Plugins/HeliosTimerDescriptor.swift
@@ -1,0 +1,40 @@
+//
+//  HeliosTimerDescriptor.swift
+//  Helios
+//
+//  Descriptor for timer extension points. Separates declaration metadata
+//  (name) from instance construction (makeTimer).
+//
+
+import Foundation
+import Vapor
+import Queues
+
+/// A timer declaration that pairs a name with a context-aware timer factory.
+public struct HeliosTimerDescriptor {
+
+    /// Human-readable timer name for logging / debugging.
+    public let name: String
+
+    /// Factory that receives a `HeliosTimerContext` and returns a configured timer.
+    public let makeTimer: (HeliosTimerContext) -> HeliosTimer
+
+    public init(
+        name: String,
+        makeTimer: @escaping (HeliosTimerContext) -> HeliosTimer
+    ) {
+        self.name = name
+        self.makeTimer = makeTimer
+    }
+}
+
+// MARK: - Convenience initializer from HeliosTimer type
+
+extension HeliosTimerDescriptor {
+
+    /// Create a descriptor that uses the timer type's context-aware init.
+    public init<T: HeliosTimer>(name: String? = nil, timer: T.Type) {
+        self.name = name ?? String(describing: T.self)
+        self.makeTimer = { context in T.init(context: context) }
+    }
+}

--- a/Tests/HeliosTests/DescriptorTests.swift
+++ b/Tests/HeliosTests/DescriptorTests.swift
@@ -1,0 +1,196 @@
+//
+//  DescriptorTests.swift
+//  HeliosTests
+//
+//  Tests for descriptor/provider extension point API (#16).
+//
+
+import XCTest
+import XCTVapor
+import Vapor
+import Queues
+@testable import Helios
+
+final class DescriptorTests: XCTestCase {
+
+    // MARK: - Route descriptors
+
+    func testRouteDescriptorRegistration() throws {
+        let delegate = TestDelegate()
+        delegate.routeDescriptorList = [
+            HeliosRouteDescriptor(path: "desc-echo", method: .GET, handler: EchoHandler.self)
+        ]
+
+        let app = try makeTestApp(delegate: delegate)
+        defer { app.shutdown() }
+
+        try app.test(.GET, "desc-echo") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "echo-ok")
+        }
+    }
+
+    func testRouteDescriptorWithClosureFactory() throws {
+        let delegate = TestDelegate()
+        delegate.routeDescriptorList = [
+            HeliosRouteDescriptor(path: "closure-echo", method: .POST) { _ in
+                EchoHandler()
+            }
+        ]
+
+        let app = try makeTestApp(delegate: delegate)
+        defer { app.shutdown() }
+
+        try app.test(.POST, "closure-echo") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "echo-ok")
+        }
+    }
+
+    func testRouteDescriptorTakesPriorityOverLegacy() throws {
+        let delegate = TestDelegate()
+        // Legacy route (should be ignored when descriptors are present)
+        delegate.routeTable = ["legacy": [.GET: EchoHandler.builder]]
+        // Descriptor route
+        delegate.routeDescriptorList = [
+            HeliosRouteDescriptor(path: "desc-only", method: .GET, handler: EchoHandler.self)
+        ]
+
+        let app = try makeTestApp(delegate: delegate)
+        defer { app.shutdown() }
+
+        // Descriptor route works
+        try app.test(.GET, "desc-only") { res in
+            XCTAssertEqual(res.status, .ok)
+        }
+
+        // Legacy route NOT registered (descriptors took priority)
+        try app.test(.GET, "legacy") { res in
+            XCTAssertEqual(res.status, .notFound)
+        }
+    }
+
+    func testLegacyRoutesFallbackWhenNoDescriptors() throws {
+        let delegate = TestDelegate()
+        delegate.routeTable = ["legacy-echo": [.GET: EchoHandler.builder]]
+        // No descriptors set → falls back to legacy
+
+        let app = try makeTestApp(delegate: delegate)
+        defer { app.shutdown() }
+
+        try app.test(.GET, "legacy-echo") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "echo-ok")
+        }
+    }
+
+    // MARK: - Filter descriptors
+
+    func testFilterDescriptorRegistration() throws {
+        let delegate = TestDelegate()
+        delegate.routeDescriptorList = [
+            HeliosRouteDescriptor(path: "filtered", method: .GET, handler: EchoHandler.self)
+        ]
+        delegate.filterDescriptorList = [
+            HeliosFilterDescriptor(name: "TestHeader", filter: TestHeaderFilter.self)
+        ]
+
+        let app = try makeTestApp(delegate: delegate)
+        defer { app.shutdown() }
+
+        try app.test(.GET, "filtered") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.headers.first(name: "X-Helios-Test"), "filtered")
+        }
+    }
+
+    func testFilterDescriptorTakesPriorityOverLegacy() throws {
+        let delegate = TestDelegate()
+        delegate.routeDescriptorList = [
+            HeliosRouteDescriptor(path: "test", method: .GET, handler: EchoHandler.self)
+        ]
+        // Legacy filter adds X-Helios-Test header
+        delegate.filterList = [TestHeaderFilter.builder]
+        // Descriptor filter: a no-op filter that does NOT add X-Helios-Test
+        delegate.filterDescriptorList = [
+            HeliosFilterDescriptor(name: "NoOp") { _ in NoOpFilter() }
+        ]
+
+        let app = try makeTestApp(delegate: delegate)
+        defer { app.shutdown() }
+
+        try app.test(.GET, "test") { res in
+            XCTAssertEqual(res.status, .ok)
+            // Legacy filter should NOT have run (descriptor took priority)
+            XCTAssertNil(res.headers.first(name: "X-Helios-Test"))
+        }
+    }
+
+    // MARK: - Descriptor struct construction
+
+    func testRouteDescriptorConvenienceInit() {
+        let desc = HeliosRouteDescriptor(path: "api/hello", method: .GET, handler: EchoHandler.self)
+        XCTAssertEqual(desc.path, "api/hello")
+        XCTAssertEqual(desc.method, .GET)
+    }
+
+    func testFilterDescriptorConvenienceInit() {
+        let desc = HeliosFilterDescriptor(filter: TestHeaderFilter.self)
+        XCTAssertEqual(desc.name, "TestHeaderFilter")
+    }
+
+    func testFilterDescriptorCustomName() {
+        let desc = HeliosFilterDescriptor(name: "MyFilter", filter: TestHeaderFilter.self)
+        XCTAssertEqual(desc.name, "MyFilter")
+    }
+
+    func testTaskDescriptorConstruction() {
+        let desc = HeliosTaskDescriptor(name: "test-task") { _ in
+            StubTask()
+        }
+        XCTAssertEqual(desc.name, "test-task")
+    }
+
+    func testTimerDescriptorConstruction() {
+        let desc = HeliosTimerDescriptor(name: "test-timer") { _ in
+            StubTimer()
+        }
+        XCTAssertEqual(desc.name, "test-timer")
+    }
+
+    // MARK: - Delegate default returns empty descriptors
+
+    func testDefaultDelegateReturnsEmptyDescriptors() {
+        let delegate = TestDelegate()
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        let heliosApp = makeTestHeliosApp(app: app, delegate: delegate)
+
+        XCTAssertTrue(delegate.routeDescriptors(app: heliosApp).isEmpty)
+        XCTAssertTrue(delegate.filterDescriptors(app: heliosApp).isEmpty)
+        XCTAssertTrue(delegate.taskDescriptors(app: heliosApp).isEmpty)
+        XCTAssertTrue(delegate.timerDescriptors(app: heliosApp).isEmpty)
+    }
+}
+
+// MARK: - Test Fixtures
+
+private struct NoOpFilter: HeliosFilter {
+    init() {}
+
+    func filterResponse(request: Request, response: Response) async throws -> Response {
+        return response
+    }
+}
+
+private struct StubTask: HeliosTask {
+    typealias Payload = String
+    init() {}
+    func dequeue(_ context: QueueContext, _ payload: String) async throws {}
+}
+
+private final class StubTimer: HeliosTimer {
+    required init() {}
+    func schedule(queue: Application.Queues) {}
+    func run(context: QueueContext) async throws {}
+}

--- a/Tests/HeliosTests/Fixtures/TestHeliosApp.swift
+++ b/Tests/HeliosTests/Fixtures/TestHeliosApp.swift
@@ -22,6 +22,12 @@ final class TestDelegate: HeliosAppDelegate {
     var modelList: [HeliosAnyModelBuilder] = []
     var timerList: [HeliosTimerBuilder] = []
 
+    // Descriptor-based (new API)
+    var routeDescriptorList: [HeliosRouteDescriptor] = []
+    var filterDescriptorList: [HeliosFilterDescriptor] = []
+    var taskDescriptorList: [HeliosTaskDescriptor] = []
+    var timerDescriptorList: [HeliosTimerDescriptor] = []
+
     func routes(app: HeliosApp) -> [String: [HTTPMethod: HeliosHandlerBuilder]] {
         routeTable
     }
@@ -40,6 +46,22 @@ final class TestDelegate: HeliosAppDelegate {
 
     func tasks(app: HeliosApp) -> [HeliosAnyTaskBuilder] {
         []
+    }
+
+    func routeDescriptors(app: HeliosApp) -> [HeliosRouteDescriptor] {
+        routeDescriptorList
+    }
+
+    func filterDescriptors(app: HeliosApp) -> [HeliosFilterDescriptor] {
+        filterDescriptorList
+    }
+
+    func taskDescriptors(app: HeliosApp) -> [HeliosTaskDescriptor] {
+        taskDescriptorList
+    }
+
+    func timerDescriptors(app: HeliosApp) -> [HeliosTimerDescriptor] {
+        timerDescriptorList
     }
 }
 
@@ -100,8 +122,18 @@ func makeTestApp(delegate: TestDelegate = TestDelegate()) throws -> Application 
     let handlerContext = HeliosHandlerContext(app: heliosApp)
     let filterContext = HeliosFilterContext(app: heliosApp)
 
-    HeliosRouteRegistrar.registerRoutes(delegate.routeTable, on: app, context: handlerContext)
-    HeliosRouteRegistrar.registerFilters(delegate.filterList, on: app, context: filterContext)
+    // Descriptor-first, fallback to legacy builders
+    if !delegate.routeDescriptorList.isEmpty {
+        HeliosRouteRegistrar.registerRoutes(delegate.routeDescriptorList, on: app, context: handlerContext)
+    } else {
+        HeliosRouteRegistrar.registerRoutes(delegate.routeTable, on: app, context: handlerContext)
+    }
+
+    if !delegate.filterDescriptorList.isEmpty {
+        HeliosRouteRegistrar.registerFilters(delegate.filterDescriptorList, on: app, context: filterContext)
+    } else {
+        HeliosRouteRegistrar.registerFilters(delegate.filterList, on: app, context: filterContext)
+    }
 
     return app
 }


### PR DESCRIPTION
## Summary

Implements **Issue #16 — 扩展点演进（阶段 3）**：将扩展点主线 API 渐进切换到 descriptor/provider 形式。

## What changed

### New descriptor types
- `HeliosRouteDescriptor` — pairs path + method with a context-aware handler factory
- `HeliosFilterDescriptor` — pairs optional name with a context-aware filter factory
- `HeliosTaskDescriptor` — pairs name with a context-aware task factory
- `HeliosTimerDescriptor` — pairs name with a context-aware timer factory

All descriptors include convenience initializers from protocol-conforming types (e.g. `HeliosRouteDescriptor(path:method:handler:)`).

### Dual-track delegate API
`HeliosAppDelegate` gains four new methods with empty defaults:
- `routeDescriptors(app:)`
- `filterDescriptors(app:)`
- `taskDescriptors(app:)`
- `timerDescriptors(app:)`

### Descriptor-first resolution
`HeliosApp` and `HeliosRouteRegistrar` use descriptor-first, fallback-to-legacy strategy:
- If descriptors are non-empty → use descriptors exclusively
- If descriptors are empty → fall back to legacy builder API

### No breaking changes
All existing delegate implementations continue to work unchanged. Legacy builder methods and typealiases remain.

## Migration path
Adopters can migrate one extension point at a time by overriding the corresponding `*Descriptors(app:)` method. Once all extension points use descriptors, legacy methods can be left as empty defaults.

## Tests
- 10 new tests in `DescriptorTests.swift` covering registration, priority/fallback, struct construction
- All 41 tests pass ✅

Closes #16