### PR TITLE
docs: sync README with current framework state

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,69 +10,120 @@ Helios 是一个建立在 Vapor 之上的轻量后端框架骨架，目标是服
 
 - **精简可用**
 - **容易继续长大**
-- **保留清晰的扩展点**
-
-它目前更像一个偏框架化的应用骨架：已经有统一的 App 入口、Handler / Filter / Task / Timer / Model 抽象，也已经开始补测试脚手架和后续演进路线。
-
----
-
-## 当前能力概览
-
-基于当前仓库主线，Helios 主要提供这些抽象：
-
-- `HeliosApp`
-  - 框架主入口
-  - 负责创建 `Application`、装配配置、注册路由 / 中间件 / 模型 / 队列 /定时任务等
-- `HeliosAppDelegate`
-  - 外部项目接入点
-  - 通过 delegate 提供 routes / models / filters / timers / tasks
-- `HeliosHandler`
-  - HTTP handler 抽象
-- `HeliosFilter`
-  - 请求 / 响应过滤器抽象，基于 Vapor `AsyncMiddleware`
-- `HeliosTask`
-  - 后台任务抽象
-- `HeliosTimer`
-  - 定时任务抽象
-- `HeliosModel`
-  - Fluent model 抽象
-- `HeliosAppConfig`
-  - 当前配置读取入口（后续会重构为 typed config）
-
----
-
-## 项目状态
-
-Helios 目前正处在“骨架已经建立，正在往长期可演进框架推进”的阶段。
-
-已经开始推进的工作包括：
-
-- 补测试脚手架（smoke / integration baseline）
-- 梳理配置系统重构计划
-- 梳理启动编排收口计划
-- 梳理扩展点依赖边界与运行时契约计划
+- **保留清晰的扩展点与演进边界**
 
 如果用一句话概括当前状态：
 
-> Helios 已经不是纯草稿，但也还没完全进入稳定框架阶段；现在最重要的是把配置、测试、启动编排和扩展边界这几层打磨硬。
+> Helios 现在已经从“个人风格的 Vapor 骨架”，推进到了“有测试、有 CI、有 typed config、有 staged setup、也有双轨扩展点 API 的轻量框架雏形”。
 
 ---
 
-## 目录结构
+## 当前已经完成的主线能力
+
+基于当前主线，Helios 已经具备这些能力：
+
+### 1. 应用主入口与 staged setup
+- `HeliosApp`
+  - 负责创建 `Application`
+  - 读取配置
+  - 以分阶段方式装配：
+    - server
+    - storage
+    - views
+    - middleware
+    - routes
+    - background jobs
+
+### 2. Typed config + fail-fast
+- `HeliosConfig`
+- `HeliosConfigLoader`
+- `HeliosAppConfig`
+
+当前配置系统已经支持：
+- typed config model
+- `base.json -> <env>.json -> environment variables` 三层加载
+- 启动阶段 fail-fast validation
+
+### 3. 扩展点主线
+- `HeliosHandler`
+- `HeliosFilter`
+- `HeliosTask`
+- `HeliosTimer`
+- `HeliosModel`
+- `HeliosAppDelegate`
+
+当前扩展点已经支持：
+- context-aware 构造（Task / Timer / Handler / Filter）
+- descriptor/provider 新接口
+- legacy builder API 兼容保留
+- descriptor-first, fallback-to-legacy 的双轨过渡
+
+### 4. Registrar 收口
+当前 route / filter / model 的主线注册逻辑已经开始从总入口收出来，框架边界比最早清楚很多。
+
+### 5. 测试脚手架
+Helios 已经有第一版测试脚手架：
+- smoke tests
+- integration tests
+- context-aware tests
+- descriptor tests
+- fixture / harness
+
+并且当前测试设计仍然坚持：
+- **零外部依赖**
+- 可本地直接跑
+
+### 6. CI baseline
+Helios 已经接入第一版 GitHub Actions CI，当前主线目标是提供：
+- lint
+- build
+- test
+
+---
+
+## 项目状态：现在处于什么阶段
+
+Helios 现在已经不是纯计划阶段，也不是只停留在“拆 issue”。
+
+已经完成并进主线的关键工作包括：
+- README 第一版
+- 测试脚手架 baseline
+- typed config / fail-fast
+- `HeliosApp.setup()` 分阶段收口
+- Task / Timer context-aware 构造
+- Handler / Filter context-aware 构造
+- descriptor/provider 双轨 API
+- GitHub Actions CI baseline
+
+更准确地说：
+
+> **基础层已经开始成形，主线方向是对的；后续重点不再是“是否要这样设计”，而是继续把 runtime contract、文档同步和真实项目迁移体验收稳。**
+
+---
+
+## 目录结构（当前主线）
 
 ```text
 Sources/Helios/
 ├── App/
 │   ├── HeliosApp.swift
-│   └── HeliosAppDelegate.swift
+│   ├── HeliosAppDelegate.swift
+│   ├── HeliosRouteRegistrar.swift
+│   ├── HeliosRouteDescriptor.swift
+│   └── HeliosFilterDescriptor.swift
 ├── Base/
-│   └── HeliosAppConfig.swift
+│   ├── HeliosAppConfig.swift
+│   ├── HeliosConfig.swift
+│   └── HeliosConfigLoader.swift
 ├── Models/
 │   └── HeliosModel.swift
 ├── Plugins/
+│   ├── HeliosContext.swift
 │   ├── HeliosFilter.swift
 │   ├── HeliosTask.swift
-│   └── HeliosTimer.swift
+│   ├── HeliosTaskDescriptor.swift
+│   ├── HeliosTimer.swift
+│   └── HeliosTimerDescriptor.swift
 └── Views/
     ├── HeliosHandler.swift
     └── HeliosView.swift
@@ -82,33 +133,35 @@ Tests/
 │   ├── Fixtures/
 │   │   └── TestHeliosApp.swift
 │   ├── SmokeTests.swift
-│   └── IntegrationTests.swift
+│   ├── IntegrationTests.swift
+│   ├── ContextAwareTests.swift
+│   └── DescriptorTests.swift
 └── README.md
 ```
 
 ---
 
-## 快速理解：Helios 怎么工作
+## 快速理解：Helios 现在怎么工作
 
 一个 Helios 应用大致按下面方式启动：
 
 1. 业务项目实现一个 `HeliosAppDelegate`
-2. 在 delegate 里提供：
-   - routes
-   - models
-   - filters
-   - timers
-   - tasks
+2. 在 delegate 中：
+   - 可以继续提供 legacy builder API
+   - 也可以开始提供新的 descriptor/provider API
 3. 使用 `HeliosApp.create(workspace:delegate:)`
-4. 框架读取 `Config/config.json`
-5. 框架在 `setup()` 里完成：
-   - HTTP server 配置
-   - MySQL 配置
-   - Redis / Queues 配置
-   - Route 注册
-   - Migration 注册
-   - Views / Middleware 配置
-   - Timer / Task 注册
+4. 框架通过 `HeliosConfigLoader` 加载配置：
+   - `base.json`
+   - `<env>.json`
+   - environment variables
+5. 框架在 `setup()` 中分阶段完成装配：
+   - HTTP server
+   - MySQL / Redis / Queues
+   - models / migrations
+   - views / static files
+   - filters
+   - routes
+   - timers / tasks
 6. 调用 `run()` 启动应用
 
 ---
@@ -117,23 +170,21 @@ Tests/
 
 ### 1. 添加依赖
 
-在你的 Swift Package 中依赖 Helios：
-
 ```swift
 .package(url: "https://github.com/enums/Helios.git", branch: "main")
 ```
 
-### 2. 实现一个最小 Delegate
+### 2. 实现一个最小 Delegate（legacy 路径）
 
 ```swift
 import Vapor
 import Helios
 
 final class AppDelegate: HeliosAppDelegate {
-    func routes(app: HeliosApp) -> [String : [HTTPMethod : HeliosHandlerBuilder]] {
+    func routes(app: HeliosApp) -> [String: [HTTPMethod: HeliosHandlerBuilder]] {
         [
             "/ping": [
-                .GET: PingHandler.builder,
+                .GET: PingHandler.builder
             ]
         ]
     }
@@ -150,29 +201,31 @@ struct PingHandler: HeliosHandler {
 
 ### 3. 准备配置文件
 
-当前版本默认从下面路径读取配置：
+当前推荐配置组织方式：
 
 ```text
-<workspace>/Config/config.json
+Config/
+  base.json
+  development.json
+  production.json
 ```
 
-例如：
+环境选择通过：
 
-```json
-{
-  "hostname": "0.0.0.0",
-  "port": "8080",
-  "mysql_host": "127.0.0.1",
-  "mysql_port": "3306",
-  "mysql_username": "root",
-  "mysql_password": "password",
-  "mysql_database": "helios",
-  "redis_host": "127.0.0.1",
-  "redis_port": "6379"
-}
+```bash
+HELIOS_ENV=development
 ```
 
-> 注意：这套配置方案是当前实现，后续会升级为 typed config + 分层加载 + fail-fast。
+覆盖关键项可通过环境变量，例如：
+
+```bash
+HELIOS_SERVER_HOST=0.0.0.0
+HELIOS_SERVER_PORT=8080
+HELIOS_MYSQL_HOST=127.0.0.1
+HELIOS_MYSQL_USERNAME=root
+HELIOS_MYSQL_PASSWORD=secret
+HELIOS_MYSQL_DATABASE=helios
+```
 
 ### 4. 启动应用
 
@@ -183,9 +236,33 @@ try helios.run()
 
 ---
 
-## 测试
+## 新旧扩展点 API：现在如何理解
 
-Helios 现在已经有第一版测试脚手架。
+Helios 当前采用的是**双轨过渡**：
+
+### Legacy API（仍然支持）
+- route dictionary
+- handler / filter / task / timer builder
+
+### New API（推荐主线）
+- `HeliosRouteDescriptor`
+- `HeliosFilterDescriptor`
+- `HeliosTaskDescriptor`
+- `HeliosTimerDescriptor`
+
+当前框架行为是：
+
+> **descriptor-first, fallback-to-legacy**
+
+也就是说：
+- 如果你提供了 descriptor，新接口优先
+- 如果 descriptor 为空，就回退到旧 builder API
+
+这让迁移可以逐步进行，而不是一次性重写所有接入点。
+
+---
+
+## 测试
 
 运行：
 
@@ -193,102 +270,94 @@ Helios 现在已经有第一版测试脚手架。
 swift test
 ```
 
-当前测试特点：
+当前测试覆盖：
+- smoke
+- integration
+- context-aware 构造
+- descriptor/provider API
 
-- 覆盖 smoke + integration baseline
-- 零外部依赖
-- 不需要 MySQL / Redis 即可跑
-- 后续 issue 会继续在这套脚手架上补更多测试
+测试特点：
+- **零外部依赖**
+- fixture 可复用
+- 后续 runtime contract / 迁移路径都可以继续在这套脚手架上补测试
 
 更详细说明见：
-
 - `Tests/README.md`
 
 ---
 
-## 当前已知限制
+## CI
 
-Helios 目前还有一些明确待演进的点：
+Helios 已经接入第一版 GitHub Actions CI。
 
-1. **配置系统偏弱**
-   - 当前还是基于 `[String: String]`
-   - 缺少 typed config / validate / env override
+当前 baseline 目标：
+- lint
+- build
+- test
 
-2. **启动编排过于集中**
-   - `HeliosApp.setup()` 现在承担了过多职责
+设计原则是：
+- 先提供稳定红绿反馈
+- 先不把 service containers / release workflow / 重型 matrix 一起拉进来
 
-3. **扩展点依赖边界还不够清晰**
-   - `Handler / Task / Timer` 目前更偏约定驱动
-
-4. **运行时契约仍然偏薄**
-   - 尤其是任务幂等、失败策略、关停行为、可观测性
-
-5. **README / 文档 / 版本治理还在补齐中**
-
-这些都已经被拆成了独立 issue，在逐步推进。
+也就是说，当前 CI 更偏“基础健康检查”，不是最终形态。
 
 ---
 
-## 路线图（当前已拆成 issue）
+## 当前已知限制 / 仍在演进的方向
 
-当前主线计划包括：
+虽然主线已经推进很多，但 Helios 还没有完全收口到“成熟框架”阶段。
 
-- **#3** 配置系统重构：typed config + 分层加载 + fail-fast
-- **#4** 启动编排收口：拆分 `HeliosApp setup` 阶段与子系统边界
-- **#5** 扩展点演进：明确 `Handler / Task / Timer` 的依赖边界
-- **#6** 后台运行时契约：补齐 `Task / Timer` 的幂等、重试与关停语义
-- **#7** 质量基线建设：建立 smoke / integration test 与版本治理最小集
-- **#8** 测试脚手架计划：建立 Helios 的 smoke / integration baseline
+当前仍需持续演进的重点包括：
 
-当前优先级已经调整为：
+1. **runtime contract 仍然偏薄**
+   - 尤其是 task / timer 的幂等、失败策略、关停语义、可观测性
+2. **README / docs 需要持续跟上主线代码**
+3. **真实下游迁移体验还需要继续验证**
+   - 尤其是 Blog 这种真实接入方
+4. **CI baseline 还在继续收稳**
+   - 目前主线已经接通，但版本 / runner 组合仍在打磨
 
-- **P0**: #8 测试脚手架（已完成第一版）
-- **P1**: #3 配置系统重构、#4 启动编排收口
-- **P2**: #5 扩展点演进、#6 后台运行时契约
-- **P3**: #7 质量基线建设
+所以当前更准确的判断是：
+
+> **Helios 已经具备了“进入持续演进”的基础设施，但还在继续打磨长期运行与迁移体验。**
 
 ---
 
 ## 适用场景
 
 Helios 当前更适合：
-
 - 你自己主导的 Swift 服务端项目
 - 中小型网站或 API 服务
 - 希望长期跑在 Linux 上
-- 愿意接受“目前还在继续打磨框架边界”这个事实
+- 希望框架精简，但不是纯散装 Vapor app
 
-它暂时**不适合**期待以下特性的场景：
-
+它目前还不适合期待以下特性的场景：
 - 开箱即用的大型企业级平台能力
-- 已成熟稳定的多数据库 / 多队列 / 多租户框架抽象
+- 成熟的多数据库 / 多队列 / 多租户抽象
 - 非常重的插件生态或复杂配置中心
 
 ---
 
-## 设计倾向
+## 现在如果你准备继续推进 Helios，建议先看哪里
 
-Helios 的当前设计倾向可以概括成：
-
-- 基于 Vapor，但不只是直接写 Vapor app
-- 用统一抽象把常见接入点收出来
-- 优先保持代码短、路径清楚、后续可收口
-- 先解决真实项目的可用性，再补框架治理与边界质量
-
----
-
-## 开发说明
-
-如果你准备继续推进 Helios，本仓库当前最值得优先看的文件是：
-
+最值得优先看的主线文件：
 - `Sources/Helios/App/HeliosApp.swift`
+- `Sources/Helios/Base/HeliosConfig.swift`
+- `Sources/Helios/Base/HeliosConfigLoader.swift`
 - `Sources/Helios/App/HeliosAppDelegate.swift`
-- `Sources/Helios/Base/HeliosAppConfig.swift`
+- `Sources/Helios/App/HeliosRouteRegistrar.swift`
 - `Tests/HeliosTests/Fixtures/TestHeliosApp.swift`
 - `Tests/README.md`
 
-如果你要从当前路线图里挑一张卡先继续做，建议优先从：
+如果你准备继续推进下一阶段，优先建议：
+- runtime contract / observability
+- 真实下游迁移验证
+- README / docs 持续同步
 
-- **#3 配置系统重构**
+---
 
-开始，因为这会直接影响后续所有能力的稳定演进。
+## 当前总体判断
+
+如果用一句话总结今天这个阶段的 Helios：
+
+> **方向正确，基础层已经成形，主线已经能支撑继续往“轻量但可演进的 Linux 后端框架”推进。**


### PR DESCRIPTION
## Summary

Sync README with the current Helios mainline after the first wave of framework work landed.

### Update included
- current framework status
- typed config / fail-fast description
- staged setup
- context-aware extension points
- descriptor/provider dual-track API
- expanded test scaffold coverage
- current CI baseline
- refreshed limitations / next-step framing

## Why
The previous README was already falling behind the codebase. This PR updates the documentation so it reflects what Helios actually is today, not what it was several PRs ago.

Related to #2
