### PR TITLE
chore: add local lint script

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,22 @@ Helios 当前采用的是**双轨过渡**：
 - 如果你提供了 descriptor，新接口优先
 - 如果 descriptor 为空，就回退到旧 builder API
 
+---
+
+## 本地 lint
+
+在仓库根目录运行：
+
+```bash
+./scripts/lint.sh
+```
+
+可选：直接使用 `swiftlint`（与 CI lint 行为对齐，默认在仓库根目录执行）：
+
+```bash
+swiftlint
+```
+
 这让迁移可以逐步进行，而不是一次性重写所有接入点。
 
 ---

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v swiftlint >/dev/null 2>&1; then
+  echo "error: swiftlint is not installed. Install SwiftLint and retry." >&2
+  exit 127
+fi
+
+swiftlint "$@"


### PR DESCRIPTION
Closes #32

## Summary
- add a local SwiftLint entrypoint aligned with the current CI lint step
- document the local lint command in README

## Usage
- run `./scripts/lint.sh`
- optionally pass through SwiftLint flags, for example `./scripts/lint.sh --strict`

The script intentionally stays thin and simply executes `swiftlint` from the repo root, so local behavior stays aligned with the current CI lint rule set.
