### PR TITLE
refactor: remove deprecated config backward compatibility

### DIFF
--- a/Sources/Helios/Base/HeliosAppConfig.swift
+++ b/Sources/Helios/Base/HeliosAppConfig.swift
@@ -2,8 +2,7 @@
 //  HeliosAppConfig.swift
 //  Helios
 //
-//  Facade combining workspace paths with typed configuration.
-//  Now backed by HeliosRuntimeConfig; legacy HeliosConfig available via `typed`.
+//  Facade combining workspace paths with typed runtime configuration.
 //
 
 import Foundation
@@ -11,7 +10,7 @@ import Vapor
 
 public final class HeliosAppConfig {
 
-    // MARK: - Legacy path properties (backward compat)
+    // MARK: - Path properties
 
     public let workspacePath: String
     public let publicPath: String
@@ -19,16 +18,10 @@ public final class HeliosAppConfig {
     public let resourcesPath: String
     public let configPath: String
 
-    // MARK: - New primary config
+    // MARK: - Runtime config
 
-    /// The new framework-agnostic runtime configuration.
+    /// The framework-agnostic runtime configuration.
     public let runtime: HeliosRuntimeConfig
-
-    // MARK: - Legacy typed config (backward compat)
-
-    /// Legacy typed config derived from the runtime config.
-    @available(*, deprecated, renamed: "runtime", message: "Use `runtime` (HeliosRuntimeConfig) for new code.")
-    public var typed: HeliosConfig { runtime.asLegacyConfig() }
 
     // MARK: - Init (from DirectoryConfiguration — production path)
 
@@ -45,7 +38,7 @@ public final class HeliosAppConfig {
         runtime = runtimeCfg
     }
 
-    // MARK: - Init (from HeliosRuntimeConfig — preferred new path)
+    // MARK: - Init (from HeliosRuntimeConfig — preferred)
 
     public init(workspacePath path: String, runtime runtimeConfig: HeliosRuntimeConfig) {
         let root = path.hasSuffix("/") ? path : path + "/"
@@ -55,32 +48,6 @@ public final class HeliosAppConfig {
         resourcesPath = root + "Resources/"
         configPath    = root + "Config/"
         runtime = HeliosAppConfig.patchResources(runtimeConfig, workspace: root)
-    }
-
-    // MARK: - Init (from legacy HeliosConfig — test/backward compat)
-
-    /// Test-only initializer: inject a pre-built config without loading from disk.
-    @available(*, deprecated, message: "Use init(workspacePath:runtime:) with HeliosRuntimeConfig instead.")
-    public init(workspacePath path: String, config: HeliosConfig) {
-        let root = path.hasSuffix("/") ? path : path + "/"
-        workspacePath = root
-        publicPath    = root + "Public/"
-        viewsPath     = root + "Views/"
-        resourcesPath = root + "Resources/"
-        configPath    = root + "Config/"
-
-        let runtimeCfg = HeliosRuntimeConfig(
-            environment: EnvironmentConfig(
-                profile: .development,
-                host: config.server.host,
-                port: config.server.port
-            ),
-            resources: ResourceConfig.derived(from: root),
-            mysql: config.mysql,
-            redis: config.redis,
-            features: config.features
-        )
-        runtime = runtimeCfg
     }
 
     // MARK: - Helpers

--- a/Sources/Helios/Base/HeliosConfig.swift
+++ b/Sources/Helios/Base/HeliosConfig.swift
@@ -2,46 +2,12 @@
 //  HeliosConfig.swift
 //  Helios
 //
-//  Typed configuration model for Helios.
-//  Replaces the old [String: String] + @dynamicMemberLookup approach.
-//
-//  NOTE: HeliosConfig and ServerConfig are deprecated in favour of HeliosRuntimeConfig.
-//  MySQLConfig, RedisConfig, FeatureFlags, TLSMode and AppEnv are still used by
-//  HeliosRuntimeConfig and remain non-deprecated.
+//  Shared configuration sub-types used by HeliosRuntimeConfig.
 //
 
 import Foundation
 
-// MARK: - Top-level Config (deprecated facade)
-
-// swiftlint:disable:next line_length
-@available(*, deprecated, renamed: "HeliosRuntimeConfig", message: "Use HeliosRuntimeConfig for new code. HeliosConfig will be removed in a future release.")
-public struct HeliosConfig {
-    public let server: ServerConfig
-    public let mysql: MySQLConfig
-    public let redis: RedisConfig
-    public let features: FeatureFlags
-
-    public init(server: ServerConfig, mysql: MySQLConfig, redis: RedisConfig, features: FeatureFlags) {
-        self.server = server
-        self.mysql = mysql
-        self.redis = redis
-        self.features = features
-    }
-}
-
-// MARK: - Sub-configs
-
-@available(*, deprecated, message: "Use EnvironmentConfig (host/port) for new code.")
-public struct ServerConfig {
-    public let host: String
-    public let port: Int
-
-    public init(host: String = "0.0.0.0", port: Int = 8080) {
-        self.host = host
-        self.port = port
-    }
-}
+// MARK: - Storage configs
 
 public struct MySQLConfig: Codable, Sendable {
     public let host: String

--- a/Sources/Helios/Base/HeliosConfigLoader.swift
+++ b/Sources/Helios/Base/HeliosConfigLoader.swift
@@ -3,8 +3,7 @@
 //  Helios
 //
 //  Unified config loading API.
-//  New code should use `loadRuntime(configDir:)` or `HeliosRuntimeConfig.load(configDir:)`.
-//  Legacy `load(configDir:)` delegates to the new runtime system.
+//  Use `loadRuntime(configDir:)` or `HeliosRuntimeConfig.load(configDir:)`.
 //
 
 import Foundation
@@ -26,17 +25,6 @@ public enum HeliosConfigLoader {
     public static func loadRuntime(sources: [ConfigSource], configDir: String? = nil) throws -> HeliosRuntimeConfig {
         let loader = DefaultRuntimeConfigLoader()
         return try loader.load(sources: sources, configDir: configDir)
-    }
-
-    // MARK: - Legacy API (backward compat)
-
-    /// Load and return a legacy `HeliosConfig`.
-    /// Delegates to the new runtime loader and converts the result.
-    // swiftlint:disable:next line_length
-    @available(*, deprecated, renamed: "loadRuntime(configDir:)", message: "Use loadRuntime(configDir:) which returns HeliosRuntimeConfig.")
-    public static func load(configDir: String) throws -> HeliosConfig {
-        let runtime = try loadRuntime(configDir: configDir)
-        return runtime.asLegacyConfig()
     }
 }
 

--- a/Sources/Helios/Base/HeliosRuntimeConfig.swift
+++ b/Sources/Helios/Base/HeliosRuntimeConfig.swift
@@ -12,7 +12,7 @@ import Foundation
 
 /// The primary framework-level configuration for Helios.
 ///
-/// Replaces the application-coupled `HeliosConfig` with a framework-agnostic structure.
+/// The primary framework-level configuration for Helios.
 /// Storage (MySQL, Redis) is optional — nil means not configured; apps handle their own storage
 /// via delegate or extension.
 public struct HeliosRuntimeConfig: Codable, Sendable {
@@ -34,7 +34,7 @@ public struct HeliosRuntimeConfig: Codable, Sendable {
     /// Ordered config sources used to build this config (for introspection).
     public let configSources: [ConfigSource]
 
-    // MARK: Optional legacy storage (kept for backward compatibility)
+    // MARK: Optional storage
 
     /// MySQL database configuration. `nil` means no database configured.
     public let mysql: MySQLConfig?
@@ -42,7 +42,7 @@ public struct HeliosRuntimeConfig: Codable, Sendable {
     /// Redis cache/queue configuration. `nil` means no Redis configured.
     public let redis: RedisConfig?
 
-    /// Legacy feature flags.
+    /// Feature flags.
     public let features: FeatureFlags
 
     // MARK: Init
@@ -96,20 +96,6 @@ public struct HeliosRuntimeConfig: Codable, Sendable {
         )
     )
 
-    // MARK: - Legacy bridge
-
-    /// Convert to legacy `HeliosConfig` for backward compat code paths.
-    /// Uses server config from `environment`. Storage defaults to empty strings if nil.
-    @available(*, deprecated, message: "Bridge method for legacy HeliosConfig consumers.")
-    public func asLegacyConfig() -> HeliosConfig {
-        HeliosConfig(
-            server: ServerConfig(host: environment.host, port: environment.port),
-            mysql: mysql ?? MySQLConfig(host: "", username: "", password: "", database: ""),
-            redis: redis ?? RedisConfig(),
-            features: features
-        )
-    }
-
     // MARK: - Loader
 
     /// Load a `HeliosRuntimeConfig` from a standard config directory using the default loader.
@@ -119,7 +105,6 @@ public struct HeliosRuntimeConfig: Codable, Sendable {
 
         var sources: [ConfigSource] = [
             .file(path: dir + "base.json"),
-            .file(path: dir + "config.json"),       // legacy fallback
             .file(path: dir + "\(env.rawValue).json"),
             .env(prefix: "HELIOS_"),
         ]

--- a/Sources/Helios/Base/RuntimeConfigLoader.swift
+++ b/Sources/Helios/Base/RuntimeConfigLoader.swift
@@ -69,19 +69,12 @@ public struct DefaultRuntimeConfigLoader: RuntimeConfigLoader {
 
     private func buildEnvironment(from raw: [String: Any]) -> EnvironmentConfig {
         let envRaw = raw["environment"] as? [String: Any] ?? [:]
-        let serverRaw = raw["server"] as? [String: Any] ?? [:]
 
         let profileStr = stringValue(envRaw["profile"]) ?? ""
         let profile = EnvironmentProfile(rawValue: profileStr) ?? .detect()
 
-        let host = stringValue(envRaw["host"])
-            ?? stringValue(serverRaw["host"])
-            ?? stringValue(raw["hostname"])
-            ?? "0.0.0.0"
-        let port = intValue(envRaw["port"])
-            ?? intValue(serverRaw["port"])
-            ?? intValue(raw["port"])
-            ?? 8080
+        let host = stringValue(envRaw["host"]) ?? "0.0.0.0"
+        let port = intValue(envRaw["port"]) ?? 8080
 
         let logLevelStr = stringValue(envRaw["logLevel"]) ?? "info"
         let logLevel = Logger.Level(rawValue: logLevelStr) ?? .info
@@ -161,18 +154,13 @@ public struct DefaultRuntimeConfigLoader: RuntimeConfigLoader {
     // MARK: - MySQL (optional)
 
     private func buildMySQL(from raw: [String: Any]) -> MySQLConfig? {
-        let section = raw["mysql"] as? [String: Any] ?? [:]
-        guard let host = stringValue(section["host"])
-                ?? stringValue(raw["mysql_host"]),
+        guard let section = raw["mysql"] as? [String: Any],
+              let host = stringValue(section["host"]),
               !host.isEmpty else { return nil }
-        let port = intValue(section["port"])
-            ?? intValue(raw["mysql_port"]) ?? 3306
-        let username = stringValue(section["username"])
-            ?? stringValue(raw["mysql_username"]) ?? ""
-        let password = stringValue(section["password"])
-            ?? stringValue(raw["mysql_password"]) ?? ""
-        let database = stringValue(section["database"])
-            ?? stringValue(raw["mysql_database"]) ?? ""
+        let port = intValue(section["port"]) ?? 3306
+        let username = stringValue(section["username"]) ?? ""
+        let password = stringValue(section["password"]) ?? ""
+        let database = stringValue(section["database"]) ?? ""
         let tls = TLSMode(
             rawValue: stringValue(section["tls"]) ?? "disable"
         ) ?? .disable
@@ -186,16 +174,12 @@ public struct DefaultRuntimeConfigLoader: RuntimeConfigLoader {
     // MARK: - Redis (optional)
 
     private func buildRedis(from raw: [String: Any]) -> RedisConfig? {
-        let section = raw["redis"] as? [String: Any]
-        let dict = section ?? [:]
-        let host = stringValue(dict["host"])
-            ?? stringValue(raw["redis_host"])
-        let port = intValue(dict["port"])
-            ?? intValue(raw["redis_port"])
-        guard section != nil || host != nil || port != nil else {
+        guard let section = raw["redis"] as? [String: Any] else {
             return nil
         }
-        return RedisConfig(host: host ?? "127.0.0.1", port: port ?? 6379)
+        let host = stringValue(section["host"]) ?? "127.0.0.1"
+        let port = intValue(section["port"]) ?? 6379
+        return RedisConfig(host: host, port: port)
     }
 
     // MARK: - Features
@@ -203,8 +187,7 @@ public struct DefaultRuntimeConfigLoader: RuntimeConfigLoader {
     private func buildFeatures(from raw: [String: Any]) -> FeatureFlags {
         let feat = raw["features"] as? [String: Any] ?? [:]
         return FeatureFlags(
-            autoMigrate: boolValue(feat["autoMigrate"])
-                ?? boolValue(raw["auto_migrate"]) ?? false,
+            autoMigrate: boolValue(feat["autoMigrate"]) ?? false,
             serveLeaf: boolValue(feat["serveLeaf"]) ?? true,
             enableQueues: boolValue(feat["enableQueues"]) ?? true,
             enableTimers: boolValue(feat["enableTimers"]) ?? true,

--- a/Tests/HeliosTests/ConfigTests.swift
+++ b/Tests/HeliosTests/ConfigTests.swift
@@ -2,9 +2,7 @@
 //  ConfigTests.swift
 //  HeliosTests
 //
-//  Backward-compatibility and cross-generation bridge tests.
-//  Tests that legacy HeliosConfig types, deprecated HeliosConfigLoader.load(),
-//  and the HeliosAppConfig facade still work correctly through the new runtime system.
+//  Config loading, validation, and HeliosAppConfig facade tests.
 //
 //  New-module unit tests live in their dedicated files:
 //    BootstrapPhaseTests, RuntimeConfigTests, ConfigSourceTests,
@@ -16,13 +14,7 @@ import XCTest
 
 final class ConfigTests: XCTestCase {
 
-    // MARK: - Legacy type defaults (backward compat)
-
-    func testDefaultServerConfig() {
-        let server = ServerConfig()
-        XCTAssertEqual(server.host, "0.0.0.0")
-        XCTAssertEqual(server.port, 8080)
-    }
+    // MARK: - Shared type defaults
 
     func testDefaultFeatureFlags() {
         let flags = FeatureFlags()
@@ -45,13 +37,13 @@ final class ConfigTests: XCTestCase {
         XCTAssertEqual(AppEnv(rawValue: "testing"), .testing)
     }
 
-    // MARK: - Legacy HeliosConfigLoader.load() (deprecated, bridges to runtime)
+    // MARK: - Config loading (nested keys only)
 
     func testLoadBaseConfig() throws {
         let dir = try makeTempConfigDir(files: [
             "base.json": """
             {
-                "server": { "host": "localhost", "port": 3000 },
+                "environment": { "host": "localhost", "port": 3000 },
                 "mysql": { "host": "db.local", "port": 3306, "username": "root", "password": "secret", "database": "helios_dev" },
                 "redis": { "host": "redis.local", "port": 6380 }
             }
@@ -59,69 +51,42 @@ final class ConfigTests: XCTestCase {
         ])
         defer { try? FileManager.default.removeItem(atPath: dir) }
 
-        let config = try HeliosConfigLoader.load(configDir: dir)
-        XCTAssertEqual(config.server.host, "localhost")
-        XCTAssertEqual(config.server.port, 3000)
-        XCTAssertEqual(config.mysql.host, "db.local")
-        XCTAssertEqual(config.mysql.port, 3306)
-        XCTAssertEqual(config.mysql.username, "root")
-        XCTAssertEqual(config.mysql.password, "secret")
-        XCTAssertEqual(config.mysql.database, "helios_dev")
-        XCTAssertEqual(config.redis.host, "redis.local")
-        XCTAssertEqual(config.redis.port, 6380)
-    }
-
-    func testLegacyConfigJsonFallback() throws {
-        let dir = try makeTempConfigDir(files: [
-            "config.json": """
-            {
-                "hostname": "legacy-host",
-                "port": "9090",
-                "mysql_host": "legacy-db",
-                "mysql_port": "3307",
-                "mysql_username": "admin",
-                "mysql_password": "pw",
-                "mysql_database": "legacy_db",
-                "redis_host": "legacy-redis",
-                "redis_port": "6381"
-            }
-            """
-        ])
-        defer { try? FileManager.default.removeItem(atPath: dir) }
-
-        let config = try HeliosConfigLoader.load(configDir: dir)
-        XCTAssertEqual(config.server.host, "legacy-host")
-        XCTAssertEqual(config.server.port, 9090)
-        XCTAssertEqual(config.mysql.host, "legacy-db")
-        XCTAssertEqual(config.mysql.database, "legacy_db")
-        XCTAssertEqual(config.redis.host, "legacy-redis")
-        XCTAssertEqual(config.redis.port, 6381)
+        let config = try HeliosConfigLoader.loadRuntime(configDir: dir)
+        XCTAssertEqual(config.environment.host, "localhost")
+        XCTAssertEqual(config.environment.port, 3000)
+        XCTAssertEqual(config.mysql?.host, "db.local")
+        XCTAssertEqual(config.mysql?.port, 3306)
+        XCTAssertEqual(config.mysql?.username, "root")
+        XCTAssertEqual(config.mysql?.password, "secret")
+        XCTAssertEqual(config.mysql?.database, "helios_dev")
+        XCTAssertEqual(config.redis?.host, "redis.local")
+        XCTAssertEqual(config.redis?.port, 6380)
     }
 
     func testEnvOverrideMergesOntoBase() throws {
         let dir = try makeTempConfigDir(files: [
             "base.json": """
             {
-                "server": { "host": "0.0.0.0", "port": 8080 },
+                "environment": { "host": "0.0.0.0", "port": 8080 },
                 "mysql": { "host": "localhost", "username": "dev", "password": "dev", "database": "helios" },
                 "redis": { "host": "127.0.0.1" }
             }
             """,
             "development.json": """
             {
-                "server": { "port": 3000 },
+                "environment": { "port": 3000 },
                 "mysql": { "password": "dev-override" }
             }
             """
         ])
         defer { try? FileManager.default.removeItem(atPath: dir) }
 
-        let config = try HeliosConfigLoader.load(configDir: dir)
-        XCTAssertEqual(config.server.port, 3000)
-        XCTAssertEqual(config.mysql.password, "dev-override")
-        XCTAssertEqual(config.server.host, "0.0.0.0")
-        XCTAssertEqual(config.mysql.host, "localhost")
-        XCTAssertEqual(config.mysql.username, "dev")
+        let config = try HeliosConfigLoader.loadRuntime(configDir: dir)
+        XCTAssertEqual(config.environment.port, 3000)
+        XCTAssertEqual(config.mysql?.password, "dev-override")
+        XCTAssertEqual(config.environment.host, "0.0.0.0")
+        XCTAssertEqual(config.mysql?.host, "localhost")
+        XCTAssertEqual(config.mysql?.username, "dev")
     }
 
     func testFeatureFlagsFromConfig() throws {
@@ -135,7 +100,7 @@ final class ConfigTests: XCTestCase {
         ])
         defer { try? FileManager.default.removeItem(atPath: dir) }
 
-        let config = try HeliosConfigLoader.load(configDir: dir)
+        let config = try HeliosConfigLoader.loadRuntime(configDir: dir)
         XCTAssertTrue(config.features.autoMigrate)
         XCTAssertFalse(config.features.serveLeaf)
         XCTAssertFalse(config.features.enableQueues)
@@ -143,7 +108,7 @@ final class ConfigTests: XCTestCase {
         XCTAssertTrue(config.features.serveStaticFiles)
     }
 
-    // MARK: - Legacy validation (through runtime system)
+    // MARK: - Validation
 
     func testValidationFailsOnMissingMySQLHost() {
         let config = HeliosRuntimeConfig(
@@ -176,44 +141,7 @@ final class ConfigTests: XCTestCase {
         XCTAssertNil(runtime.redis)
     }
 
-    // MARK: - asLegacyConfig bridge
-
-    func testAsLegacyConfigBridge() {
-        let runtime = HeliosRuntimeConfig(
-            environment: EnvironmentConfig(host: "bridge-host", port: 7777),
-            mysql: MySQLConfig(host: "mydb", username: "u", password: "p", database: "d"),
-            redis: RedisConfig(host: "myredis", port: 6379)
-        )
-        let legacy = runtime.asLegacyConfig()
-        XCTAssertEqual(legacy.server.host, "bridge-host")
-        XCTAssertEqual(legacy.server.port, 7777)
-        XCTAssertEqual(legacy.mysql.host, "mydb")
-        XCTAssertEqual(legacy.redis.host, "myredis")
-    }
-
-    func testAsLegacyConfigWithNoStorageDefaults() {
-        let runtime = HeliosRuntimeConfig(
-            environment: EnvironmentConfig(host: "h", port: 1)
-        )
-        let legacy = runtime.asLegacyConfig()
-        XCTAssertEqual(legacy.mysql.host, "")
-        XCTAssertEqual(legacy.redis.host, "127.0.0.1")
-    }
-
     // MARK: - HeliosAppConfig facade
-
-    func testAppConfigLegacyInitializer() {
-        let config = HeliosConfig(
-            server: ServerConfig(host: "test", port: 1234),
-            mysql: MySQLConfig(host: "db", username: "u", password: "p", database: "d"),
-            redis: RedisConfig(),
-            features: FeatureFlags()
-        )
-        let appConfig = HeliosAppConfig(workspacePath: "/tmp/test/", config: config)
-        XCTAssertEqual(appConfig.typed.server.host, "test")
-        XCTAssertEqual(appConfig.typed.server.port, 1234)
-        XCTAssertEqual(appConfig.workspacePath, "/tmp/test/")
-    }
 
     func testAppConfigRuntimeInitializer() {
         let runtime = HeliosRuntimeConfig(

--- a/Tests/HeliosTests/ContextAwareTests.swift
+++ b/Tests/HeliosTests/ContextAwareTests.swift
@@ -55,13 +55,13 @@ final class ContextAwareTests: XCTestCase {
     func testContextAwareTimerReceivesContext() {
         let app = Application(.testing)
         defer { app.shutdown() }
-        let config = HeliosConfig(
-            server: ServerConfig(host: "ctx-test", port: 9999),
+        let runtimeConfig = HeliosRuntimeConfig(
+            environment: EnvironmentConfig(host: "ctx-test", port: 9999),
             mysql: MySQLConfig(host: "test", username: "u", password: "p", database: "d"),
             redis: RedisConfig(),
             features: FeatureFlags()
         )
-        let appConfig = HeliosAppConfig(workspacePath: "/tmp/test/", config: config)
+        let appConfig = HeliosAppConfig(workspacePath: "/tmp/test/", runtime: runtimeConfig)
         let delegate = TestDelegate()
         let heliosApp = HeliosApp(app: app, config: appConfig, delegate: delegate)
 
@@ -98,7 +98,7 @@ private final class ContextAwareTimer: HeliosTimer {
     }
 
     required init(context: HeliosTimerContext) {
-        self.serverHost = context.app.config.typed.server.host
+        self.serverHost = context.app.config.runtime.environment.host
     }
 
     func schedule(queue: Application.Queues) {}

--- a/Tests/HeliosTests/Fixtures/TestHeliosApp.swift
+++ b/Tests/HeliosTests/Fixtures/TestHeliosApp.swift
@@ -110,14 +110,6 @@ let testRuntimeConfig = HeliosRuntimeConfig(
     )
 )
 
-/// Legacy test config (backward compat) — no real DB/Redis needed.
-let testConfig = HeliosConfig(
-    server: ServerConfig(),
-    mysql: MySQLConfig(host: "test", username: "test", password: "test", database: "test"),
-    redis: RedisConfig(),
-    features: FeatureFlags()
-)
-
 /// Create a minimal `HeliosApp` for test context construction.
 /// Does NOT connect to any external services.
 func makeTestHeliosApp(app: Application, delegate: TestDelegate = TestDelegate()) -> HeliosApp {

--- a/Tests/HeliosTests/SmokeTests.swift
+++ b/Tests/HeliosTests/SmokeTests.swift
@@ -31,7 +31,7 @@ final class SmokeTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
         let config = try? HeliosAppConfig(dir: app.directory)
-        // Config may fail without config.json — that's expected.
+        // Config may fail without base.json — that's expected.
         // We're testing that the delegate protocol defaults work.
         XCTAssertTrue(delegate.routeTable.isEmpty)
         XCTAssertTrue(delegate.filterList.isEmpty)


### PR DESCRIPTION
## Summary

Remove all legacy config backward compatibility code per [enums/Blog#43 comment](https://github.com/enums/Blog/pull/43#issuecomment-4195869367).

## Changes (9 files, -244 / +53 lines)

### Removed
- **`HeliosConfig`** and **`ServerConfig`** deprecated structs
- **`asLegacyConfig()`** bridge method on `HeliosRuntimeConfig`
- **`config.json`** legacy fallback from config source list (only `base.json` + `{profile}.json` remain)
- **`HeliosConfigLoader.load(configDir:)`** deprecated method (use `loadRuntime` instead)
- **`HeliosAppConfig.typed`** deprecated property and legacy `init(workspacePath:config:)`
- **Flat-key fallbacks** in `RuntimeConfigLoader`: `hostname`, `server.host/port`, `mysql_host`, `redis_host`, `auto_migrate` — only nested keys (`environment.host`, `mysql.host`, etc.) are now supported

### Kept (unchanged)
- `MySQLConfig`, `RedisConfig`, `FeatureFlags`, `TLSMode`, `AppEnv` — still used by `HeliosRuntimeConfig`
- Builder-based delegate API (`routes`/`filters`/`timers`/`tasks`) — separate concern
- Descriptor vs legacy builder fallback in `HeliosApp` — separate concern
- `init()` / `init(context:)` pattern on protocol types — separate concern

## Verification

- ✅ Mac build: `swift build` passes
- ✅ Mac tests: **150/150 pass, 0 failures**

## Impact

After this merges, downstream consumers (e.g. Blog) must use the nested config key format:
```json
{
  "environment": { "host": "0.0.0.0", "port": 8080 },
  "mysql": { "host": "...", "username": "...", ... },
  "redis": { "host": "..." },
  "features": { "autoMigrate": true }
}
```

@enums ready for review