### PR TITLE
fix: register filters before FileMiddleware so static files pass through filters

### DIFF
--- a/Sources/Helios/App/HeliosApp.swift
+++ b/Sources/Helios/App/HeliosApp.swift
@@ -154,31 +154,37 @@ public final class HeliosApp {
         HeliosModelRegistrar.register(delegate.models(app: self), on: app)
     }
 
-    // MARK: - Phase 5: Views & Static Files
+    // MARK: - Phase 5: Views
 
-    /// Configure Leaf template engine and static file serving.
+    /// Configure Leaf template engine.
     private func configureViews() {
         let features = config.runtime.features
 
         if features.serveLeaf {
             app.views.use(.leaf)
         }
-
-        if features.serveStaticFiles {
-            app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
-        }
     }
 
-    // MARK: - Phase 6: Middleware (Filters)
+    // MARK: - Phase 6: Middleware (Filters + Static Files)
 
-    /// Register application-level middleware / filters from the delegate.
+    /// Register application-level middleware / filters from the delegate,
+    /// then static file serving.
+    ///
+    /// Filters are registered first so they wrap all requests, including
+    /// static file requests served by `FileMiddleware`.
     /// Descriptor-based API takes priority; falls back to legacy builders.
     private func configureMiddleware() {
+        // 1. Application filters (registered first → outermost middleware)
         let descriptors = delegate.filterDescriptors(app: self)
         if !descriptors.isEmpty {
             HeliosRouteRegistrar.registerFilters(descriptors, on: app, heliosApp: self)
         } else {
             HeliosRouteRegistrar.registerFilters(delegate.filters(app: self), on: app, heliosApp: self)
+        }
+
+        // 2. Static file serving (registered after filters so files pass through filters)
+        if config.runtime.features.serveStaticFiles {
+            app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
         }
     }
 


### PR DESCRIPTION
## Problem

Phase 5 (`configureViews`) registered `FileMiddleware` before Phase 6 (`configureMiddleware`) registered user filters. Vapor middleware executes in registration order, so static file requests were served directly by `FileMiddleware` without passing through any application-level filters.

Reported by @enums in [enums/Blog#41 comment](https://github.com/enums/Blog/issues/41#issuecomment-4196255453).

## Fix

Move `FileMiddleware` registration from `configureViews()` (Phase 5) into `configureMiddleware()` (Phase 6), **after** user-defined filters are registered. Now:

1. Filters registered first → outermost middleware → see all requests
2. `FileMiddleware` registered after → only serves files that pass through filters

`configureViews()` now only handles Leaf template engine setup.

## Verification

- ✅ Mac build passes
- ✅ 150/150 tests pass, 0 failures

@enums