### PR TITLE
feat: add runtime metadata for Task/Timer descriptors (#27)

### DIFF
--- a/Sources/Helios/App/HeliosApp.swift
+++ b/Sources/Helios/App/HeliosApp.swift
@@ -221,7 +221,11 @@ public final class HeliosApp {
                 timerDescriptors.forEach { descriptor in
                     let timer = descriptor.makeTimer(timerContext)
                     timer.schedule(queue: app.queues)
-                    app.logger.info("Helios: registered \(descriptor.metadata.kind.rawValue) '\(descriptor.metadata.name)' [criticality: \(descriptor.metadata.criticality.rawValue), retry: \(descriptor.metadata.retryPolicy.logDescription)]")
+                    let meta = descriptor.metadata
+                    app.logger.info(
+                        "Helios: registered \(meta.kind.rawValue) '\(meta.name)'"
+                        + " [criticality: \(meta.criticality.rawValue), retry: \(meta.retryPolicy.logDescription)]"
+                    )
                 }
             } else {
                 delegate.timers(app: self).forEach { builder in
@@ -240,7 +244,11 @@ public final class HeliosApp {
                     return
                 }
                 task.register(queue: app.queues)
-                app.logger.info("Helios: registered \(descriptor.metadata.kind.rawValue) '\(descriptor.metadata.name)' [criticality: \(descriptor.metadata.criticality.rawValue), retry: \(descriptor.metadata.retryPolicy.logDescription)]")
+                let meta = descriptor.metadata
+                app.logger.info(
+                    "Helios: registered \(meta.kind.rawValue) '\(meta.name)'"
+                    + " [criticality: \(meta.criticality.rawValue), retry: \(meta.retryPolicy.logDescription)]"
+                )
             }
         } else {
             delegate.tasks(app: self).forEach { builder in

--- a/Sources/Helios/App/HeliosApp.swift
+++ b/Sources/Helios/App/HeliosApp.swift
@@ -221,6 +221,7 @@ public final class HeliosApp {
                 timerDescriptors.forEach { descriptor in
                     let timer = descriptor.makeTimer(timerContext)
                     timer.schedule(queue: app.queues)
+                    app.logger.info("Helios: registered \(descriptor.metadata.kind.rawValue) '\(descriptor.metadata.name)' [criticality: \(descriptor.metadata.criticality.rawValue), retry: \(descriptor.metadata.retryPolicy.logDescription)]")
                 }
             } else {
                 delegate.timers(app: self).forEach { builder in
@@ -239,6 +240,7 @@ public final class HeliosApp {
                     return
                 }
                 task.register(queue: app.queues)
+                app.logger.info("Helios: registered \(descriptor.metadata.kind.rawValue) '\(descriptor.metadata.name)' [criticality: \(descriptor.metadata.criticality.rawValue), retry: \(descriptor.metadata.retryPolicy.logDescription)]")
             }
         } else {
             delegate.tasks(app: self).forEach { builder in

--- a/Sources/Helios/App/HeliosApp.swift
+++ b/Sources/Helios/App/HeliosApp.swift
@@ -223,8 +223,7 @@ public final class HeliosApp {
                     timer.schedule(queue: app.queues)
                     let meta = descriptor.metadata
                     app.logger.info(
-                        "Helios: registered \(meta.kind.rawValue) '\(meta.name)'"
-                        + " [criticality: \(meta.criticality.rawValue), retry: \(meta.retryPolicy.logDescription)]"
+                        "Helios: registered \(meta.kind.rawValue) '\(meta.name)' [criticality: \(meta.criticality.rawValue), retry: \(meta.retryPolicy.logDescription)]"
                     )
                 }
             } else {
@@ -246,8 +245,7 @@ public final class HeliosApp {
                 task.register(queue: app.queues)
                 let meta = descriptor.metadata
                 app.logger.info(
-                    "Helios: registered \(meta.kind.rawValue) '\(meta.name)'"
-                    + " [criticality: \(meta.criticality.rawValue), retry: \(meta.retryPolicy.logDescription)]"
+                    "Helios: registered \(meta.kind.rawValue) '\(meta.name)' [criticality: \(meta.criticality.rawValue), retry: \(meta.retryPolicy.logDescription)]"
                 )
             }
         } else {

--- a/Sources/Helios/Plugins/HeliosRuntimeMetadata.swift
+++ b/Sources/Helios/Plugins/HeliosRuntimeMetadata.swift
@@ -1,0 +1,70 @@
+//
+//  HeliosRuntimeMetadata.swift
+//  Helios
+//
+//  Runtime metadata attached to Task / Timer descriptors.
+//  Part of runtime contract first pass (#27).
+//
+
+import Foundation
+
+/// Runtime metadata attached to every Task / Timer descriptor.
+public struct HeliosRuntimeMetadata: Equatable, Sendable {
+
+    /// Human-readable name for logging / debugging.
+    public let name: String
+
+    /// Whether this is a task or a timer.
+    public let kind: HeliosRuntimeKind
+
+    /// How important this job is to the application.
+    public let criticality: HeliosCriticality
+
+    /// What to do when execution fails.
+    public let retryPolicy: HeliosRetryPolicy
+
+    /// Optional human-readable schedule description (e.g. "every 5 minutes").
+    public let scheduleDescription: String?
+
+    public init(
+        name: String,
+        kind: HeliosRuntimeKind,
+        criticality: HeliosCriticality = .normal,
+        retryPolicy: HeliosRetryPolicy = .noRetry,
+        scheduleDescription: String? = nil
+    ) {
+        self.name = name
+        self.kind = kind
+        self.criticality = criticality
+        self.retryPolicy = retryPolicy
+        self.scheduleDescription = scheduleDescription
+    }
+}
+
+// MARK: - Supporting Types
+
+public enum HeliosRuntimeKind: String, Equatable, Sendable {
+    case task
+    case timer
+}
+
+public enum HeliosCriticality: String, Equatable, Sendable {
+    case normal
+    case critical
+}
+
+public enum HeliosRetryPolicy: Equatable, Sendable {
+    case noRetry
+    case fixed(maxAttempts: Int)
+}
+
+extension HeliosRetryPolicy {
+
+    /// Human-readable description for logging.
+    public var logDescription: String {
+        switch self {
+        case .noRetry: return "none"
+        case .fixed(let maxAttempts): return "fixed(\(maxAttempts))"
+        }
+    }
+}

--- a/Sources/Helios/Plugins/HeliosTaskDescriptor.swift
+++ b/Sources/Helios/Plugins/HeliosTaskDescriptor.swift
@@ -10,20 +10,31 @@ import Foundation
 import Vapor
 import Queues
 
-/// A task declaration that pairs a name with a context-aware task factory.
+/// A task declaration that pairs runtime metadata with a context-aware task factory.
 public struct HeliosTaskDescriptor {
 
+    /// Runtime metadata (name, kind, criticality, retry policy).
+    public let metadata: HeliosRuntimeMetadata
+
     /// Human-readable task name for logging / debugging.
-    public let name: String
+    public var name: String { metadata.name }
 
     /// Factory that receives a `HeliosTaskContext` and returns a configured task.
     public let makeTask: (HeliosTaskContext) -> HeliosAnyTask
 
     public init(
+        metadata: HeliosRuntimeMetadata,
+        makeTask: @escaping (HeliosTaskContext) -> HeliosAnyTask
+    ) {
+        self.metadata = metadata
+        self.makeTask = makeTask
+    }
+
+    public init(
         name: String,
         makeTask: @escaping (HeliosTaskContext) -> HeliosAnyTask
     ) {
-        self.name = name
+        self.metadata = HeliosRuntimeMetadata(name: name, kind: .task)
         self.makeTask = makeTask
     }
 }
@@ -34,7 +45,14 @@ extension HeliosTaskDescriptor {
 
     /// Create a descriptor that uses the task type's context-aware init.
     public init<T: HeliosTask>(name: String? = nil, task: T.Type) {
-        self.name = name ?? String(describing: T.self)
+        let resolvedName = name ?? String(describing: T.self)
+        self.metadata = HeliosRuntimeMetadata(name: resolvedName, kind: .task)
+        self.makeTask = { context in T.init(context: context) }
+    }
+
+    /// Create a descriptor with full metadata that uses the task type's context-aware init.
+    public init<T: HeliosTask>(metadata: HeliosRuntimeMetadata, task: T.Type) {
+        self.metadata = metadata
         self.makeTask = { context in T.init(context: context) }
     }
 }

--- a/Sources/Helios/Plugins/HeliosTimerDescriptor.swift
+++ b/Sources/Helios/Plugins/HeliosTimerDescriptor.swift
@@ -10,20 +10,31 @@ import Foundation
 import Vapor
 import Queues
 
-/// A timer declaration that pairs a name with a context-aware timer factory.
+/// A timer declaration that pairs runtime metadata with a context-aware timer factory.
 public struct HeliosTimerDescriptor {
 
+    /// Runtime metadata (name, kind, criticality, retry policy).
+    public let metadata: HeliosRuntimeMetadata
+
     /// Human-readable timer name for logging / debugging.
-    public let name: String
+    public var name: String { metadata.name }
 
     /// Factory that receives a `HeliosTimerContext` and returns a configured timer.
     public let makeTimer: (HeliosTimerContext) -> HeliosTimer
 
     public init(
+        metadata: HeliosRuntimeMetadata,
+        makeTimer: @escaping (HeliosTimerContext) -> HeliosTimer
+    ) {
+        self.metadata = metadata
+        self.makeTimer = makeTimer
+    }
+
+    public init(
         name: String,
         makeTimer: @escaping (HeliosTimerContext) -> HeliosTimer
     ) {
-        self.name = name
+        self.metadata = HeliosRuntimeMetadata(name: name, kind: .timer)
         self.makeTimer = makeTimer
     }
 }
@@ -34,7 +45,14 @@ extension HeliosTimerDescriptor {
 
     /// Create a descriptor that uses the timer type's context-aware init.
     public init<T: HeliosTimer>(name: String? = nil, timer: T.Type) {
-        self.name = name ?? String(describing: T.self)
+        let resolvedName = name ?? String(describing: T.self)
+        self.metadata = HeliosRuntimeMetadata(name: resolvedName, kind: .timer)
+        self.makeTimer = { context in T.init(context: context) }
+    }
+
+    /// Create a descriptor with full metadata that uses the timer type's context-aware init.
+    public init<T: HeliosTimer>(metadata: HeliosRuntimeMetadata, timer: T.Type) {
+        self.metadata = metadata
         self.makeTimer = { context in T.init(context: context) }
     }
 }

--- a/Tests/HeliosTests/RuntimeContractTests.swift
+++ b/Tests/HeliosTests/RuntimeContractTests.swift
@@ -39,11 +39,11 @@ final class RuntimeContractTests: XCTestCase {
     }
 
     func testMetadataEquality() {
-        let a = HeliosRuntimeMetadata(name: "x", kind: .task)
-        let b = HeliosRuntimeMetadata(name: "x", kind: .task)
-        let c = HeliosRuntimeMetadata(name: "y", kind: .task)
-        XCTAssertEqual(a, b)
-        XCTAssertNotEqual(a, c)
+        let lhs = HeliosRuntimeMetadata(name: "x", kind: .task)
+        let rhs = HeliosRuntimeMetadata(name: "x", kind: .task)
+        let other = HeliosRuntimeMetadata(name: "y", kind: .task)
+        XCTAssertEqual(lhs, rhs)
+        XCTAssertNotEqual(lhs, other)
     }
 
     // MARK: - HeliosRuntimeKind

--- a/Tests/HeliosTests/RuntimeContractTests.swift
+++ b/Tests/HeliosTests/RuntimeContractTests.swift
@@ -1,0 +1,167 @@
+//
+//  RuntimeContractTests.swift
+//  HeliosTests
+//
+//  Tests for runtime contract metadata types and descriptor integration (#27).
+//
+
+import XCTest
+import Vapor
+import Queues
+@testable import Helios
+
+final class RuntimeContractTests: XCTestCase {
+
+    // MARK: - HeliosRuntimeMetadata
+
+    func testMetadataDefaults() {
+        let meta = HeliosRuntimeMetadata(name: "test", kind: .task)
+        XCTAssertEqual(meta.name, "test")
+        XCTAssertEqual(meta.kind, .task)
+        XCTAssertEqual(meta.criticality, .normal)
+        XCTAssertEqual(meta.retryPolicy, .noRetry)
+        XCTAssertNil(meta.scheduleDescription)
+    }
+
+    func testMetadataFullInit() {
+        let meta = HeliosRuntimeMetadata(
+            name: "important-job",
+            kind: .timer,
+            criticality: .critical,
+            retryPolicy: .fixed(maxAttempts: 3),
+            scheduleDescription: "every 5 minutes"
+        )
+        XCTAssertEqual(meta.name, "important-job")
+        XCTAssertEqual(meta.kind, .timer)
+        XCTAssertEqual(meta.criticality, .critical)
+        XCTAssertEqual(meta.retryPolicy, .fixed(maxAttempts: 3))
+        XCTAssertEqual(meta.scheduleDescription, "every 5 minutes")
+    }
+
+    func testMetadataEquality() {
+        let a = HeliosRuntimeMetadata(name: "x", kind: .task)
+        let b = HeliosRuntimeMetadata(name: "x", kind: .task)
+        let c = HeliosRuntimeMetadata(name: "y", kind: .task)
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+
+    // MARK: - HeliosRuntimeKind
+
+    func testRuntimeKindRawValues() {
+        XCTAssertEqual(HeliosRuntimeKind.task.rawValue, "task")
+        XCTAssertEqual(HeliosRuntimeKind.timer.rawValue, "timer")
+    }
+
+    // MARK: - HeliosCriticality
+
+    func testCriticalityRawValues() {
+        XCTAssertEqual(HeliosCriticality.normal.rawValue, "normal")
+        XCTAssertEqual(HeliosCriticality.critical.rawValue, "critical")
+    }
+
+    // MARK: - HeliosRetryPolicy
+
+    func testRetryPolicyEquality() {
+        XCTAssertEqual(HeliosRetryPolicy.noRetry, HeliosRetryPolicy.noRetry)
+        XCTAssertEqual(HeliosRetryPolicy.fixed(maxAttempts: 3), HeliosRetryPolicy.fixed(maxAttempts: 3))
+        XCTAssertNotEqual(HeliosRetryPolicy.noRetry, HeliosRetryPolicy.fixed(maxAttempts: 1))
+        XCTAssertNotEqual(HeliosRetryPolicy.fixed(maxAttempts: 2), HeliosRetryPolicy.fixed(maxAttempts: 5))
+    }
+
+    func testRetryPolicyLogDescription() {
+        XCTAssertEqual(HeliosRetryPolicy.noRetry.logDescription, "none")
+        XCTAssertEqual(HeliosRetryPolicy.fixed(maxAttempts: 3).logDescription, "fixed(3)")
+    }
+
+    // MARK: - HeliosTaskDescriptor metadata
+
+    func testTaskDescriptorConvenienceInitMetadata() {
+        let desc = HeliosTaskDescriptor(name: "my-task") { _ in RCStubTask() }
+        XCTAssertEqual(desc.name, "my-task")
+        XCTAssertEqual(desc.metadata.kind, .task)
+        XCTAssertEqual(desc.metadata.criticality, .normal)
+        XCTAssertEqual(desc.metadata.retryPolicy, .noRetry)
+    }
+
+    func testTaskDescriptorFullMetadata() {
+        let meta = HeliosRuntimeMetadata(
+            name: "critical-task",
+            kind: .task,
+            criticality: .critical,
+            retryPolicy: .fixed(maxAttempts: 5)
+        )
+        let desc = HeliosTaskDescriptor(metadata: meta) { _ in RCStubTask() }
+        XCTAssertEqual(desc.metadata, meta)
+        XCTAssertEqual(desc.name, "critical-task")
+    }
+
+    func testTaskDescriptorTypeBasedInit() {
+        let desc = HeliosTaskDescriptor(task: RCStubTask.self)
+        XCTAssertEqual(desc.name, "RCStubTask")
+        XCTAssertEqual(desc.metadata.kind, .task)
+    }
+
+    func testTaskDescriptorTypeBasedInitCustomName() {
+        let desc = HeliosTaskDescriptor(name: "custom", task: RCStubTask.self)
+        XCTAssertEqual(desc.name, "custom")
+        XCTAssertEqual(desc.metadata.kind, .task)
+    }
+
+    func testTaskDescriptorTypeBasedInitWithMetadata() {
+        let meta = HeliosRuntimeMetadata(name: "retry-task", kind: .task, retryPolicy: .fixed(maxAttempts: 2))
+        let desc = HeliosTaskDescriptor(metadata: meta, task: RCStubTask.self)
+        XCTAssertEqual(desc.name, "retry-task")
+        XCTAssertEqual(desc.metadata.retryPolicy, .fixed(maxAttempts: 2))
+    }
+
+    // MARK: - HeliosTimerDescriptor metadata
+
+    func testTimerDescriptorConvenienceInitMetadata() {
+        let desc = HeliosTimerDescriptor(name: "my-timer") { _ in RCStubTimer() }
+        XCTAssertEqual(desc.name, "my-timer")
+        XCTAssertEqual(desc.metadata.kind, .timer)
+        XCTAssertEqual(desc.metadata.criticality, .normal)
+        XCTAssertEqual(desc.metadata.retryPolicy, .noRetry)
+    }
+
+    func testTimerDescriptorFullMetadata() {
+        let meta = HeliosRuntimeMetadata(
+            name: "critical-timer",
+            kind: .timer,
+            criticality: .critical,
+            retryPolicy: .fixed(maxAttempts: 2),
+            scheduleDescription: "hourly"
+        )
+        let desc = HeliosTimerDescriptor(metadata: meta) { _ in RCStubTimer() }
+        XCTAssertEqual(desc.metadata, meta)
+        XCTAssertEqual(desc.name, "critical-timer")
+    }
+
+    func testTimerDescriptorTypeBasedInit() {
+        let desc = HeliosTimerDescriptor(timer: RCStubTimer.self)
+        XCTAssertEqual(desc.name, "RCStubTimer")
+        XCTAssertEqual(desc.metadata.kind, .timer)
+    }
+
+    func testTimerDescriptorTypeBasedInitWithMetadata() {
+        let meta = HeliosRuntimeMetadata(name: "scheduled-cleanup", kind: .timer, criticality: .critical)
+        let desc = HeliosTimerDescriptor(metadata: meta, timer: RCStubTimer.self)
+        XCTAssertEqual(desc.name, "scheduled-cleanup")
+        XCTAssertEqual(desc.metadata.criticality, .critical)
+    }
+}
+
+// MARK: - Test Fixtures
+
+private struct RCStubTask: HeliosTask {
+    typealias Payload = String
+    init() {}
+    func dequeue(_ context: QueueContext, _ payload: String) async throws {}
+}
+
+private final class RCStubTimer: HeliosTimer {
+    required init() {}
+    func schedule(queue: Application.Queues) {}
+    func run(context: QueueContext) async throws {}
+}


### PR DESCRIPTION
## Summary

为 Task / Timer descriptor 增加 runtime metadata，是 #27（runtime contract 第一轮收口）的 **PR 1**。

## 改动

### 新增
- **`HeliosRuntimeMetadata`** — `name`, `kind`, `criticality`, `retryPolicy`, `scheduleDescription`
- **`HeliosRuntimeKind`** (.task / .timer)
- **`HeliosCriticality`** (.normal / .critical)
- **`HeliosRetryPolicy`** (.noRetry / .fixed(maxAttempts:))
- **`RuntimeContractTests`** — 16 个新测试

### 修改
- **`HeliosTaskDescriptor`** — `name: String` → `metadata: HeliosRuntimeMetadata`，`name` 变为 computed property
- **`HeliosTimerDescriptor`** — 同上
- **`HeliosApp.registerBackgroundJobs()`** — descriptor 注册时输出 info 级别日志

### 兼容性
- 所有现有 `init(name:makeTask:)` / `init(name:timer:)` 签名保持不变
- 166 个测试全部通过，0 失败

## 对应 Jarvis 方案的覆盖

| Step | 内容 | 状态 |
|------|------|------|
| Step 1 | runtime metadata 模型 | ✅ |
| Step 2 | metadata 接入 descriptor | ✅ |
| Step 3 | 最小 observability | ✅ 注册时日志 |
| Step 4 | shutdown contract | 🔜 PR 2 |

Closes #27 partially — shutdown/cancellation contract 留给 PR 2。