### PR TITLE
feat: shutdown contract, kind precondition, and extended tests

### DIFF
--- a/Docs/RuntimeContract-Shutdown.md
+++ b/Docs/RuntimeContract-Shutdown.md
@@ -1,0 +1,41 @@
+# Runtime Contract: Shutdown & Cancellation
+
+> Part of Helios runtime contract (#27). This document defines the
+> minimum behavioral guarantees for Task / Timer lifecycle during
+> application shutdown.
+
+## Rules
+
+1. **No completion guarantee for in-flight work.**
+   The framework does NOT guarantee that a Task or Timer already executing
+   will run to successful completion when shutdown is initiated.
+
+2. **No new work after shutdown.**
+   Once shutdown begins, the framework MUST NOT accept new task dispatches
+   or schedule new timer firings.
+
+3. **No silent swallowing of cancellation.**
+   If a Task or Timer is cancelled during shutdown, the cancellation MUST
+   be observable — either through logging or through the error propagation
+   path. The framework MUST NOT silently discard a cancellation.
+
+4. **Cancellation path visibility.**
+   When a Task or Timer is cancelled, logs MUST include enough context to
+   identify which job was affected (at minimum: name + kind from its
+   `HeliosRuntimeMetadata`).
+
+## Current Implementation Status
+
+- **Rule 1:** Inherent — Vapor/Queues does not add completion guarantees.
+- **Rule 2:** Inherent — `Application.shutdown()` stops the event loop.
+- **Rule 3:** Partial — errors during dequeue are logged by Queues driver,
+  but cancellation-specific logging is not yet added at the Helios layer.
+- **Rule 4:** Addressed in PR 1 (registration logging). Runtime failure
+  logging with metadata context is a future enhancement.
+
+## Future Work
+
+- Add Helios-layer error logging that attaches `HeliosRuntimeMetadata`
+  to task/timer failure events (beyond what the Queues driver provides).
+- Consider a `HeliosShutdownCoordinator` that gives in-flight critical
+  tasks a grace period before forced cancellation.

--- a/Sources/Helios/Plugins/HeliosTaskDescriptor.swift
+++ b/Sources/Helios/Plugins/HeliosTaskDescriptor.swift
@@ -26,6 +26,7 @@ public struct HeliosTaskDescriptor {
         metadata: HeliosRuntimeMetadata,
         makeTask: @escaping (HeliosTaskContext) -> HeliosAnyTask
     ) {
+        precondition(metadata.kind == .task, "HeliosTaskDescriptor requires metadata.kind == .task, got .\(metadata.kind.rawValue)")
         self.metadata = metadata
         self.makeTask = makeTask
     }
@@ -52,6 +53,7 @@ extension HeliosTaskDescriptor {
 
     /// Create a descriptor with full metadata that uses the task type's context-aware init.
     public init<T: HeliosTask>(metadata: HeliosRuntimeMetadata, task: T.Type) {
+        precondition(metadata.kind == .task, "HeliosTaskDescriptor requires metadata.kind == .task, got .\(metadata.kind.rawValue)")
         self.metadata = metadata
         self.makeTask = { context in T.init(context: context) }
     }

--- a/Sources/Helios/Plugins/HeliosTimerDescriptor.swift
+++ b/Sources/Helios/Plugins/HeliosTimerDescriptor.swift
@@ -26,6 +26,10 @@ public struct HeliosTimerDescriptor {
         metadata: HeliosRuntimeMetadata,
         makeTimer: @escaping (HeliosTimerContext) -> HeliosTimer
     ) {
+        precondition(
+            metadata.kind == .timer,
+            "HeliosTimerDescriptor requires metadata.kind == .timer, got .\(metadata.kind.rawValue)"
+        )
         self.metadata = metadata
         self.makeTimer = makeTimer
     }
@@ -52,6 +56,10 @@ extension HeliosTimerDescriptor {
 
     /// Create a descriptor with full metadata that uses the timer type's context-aware init.
     public init<T: HeliosTimer>(metadata: HeliosRuntimeMetadata, timer: T.Type) {
+        precondition(
+            metadata.kind == .timer,
+            "HeliosTimerDescriptor requires metadata.kind == .timer, got .\(metadata.kind.rawValue)"
+        )
         self.metadata = metadata
         self.makeTimer = { context in T.init(context: context) }
     }

--- a/Tests/HeliosTests/RuntimeContractTests.swift
+++ b/Tests/HeliosTests/RuntimeContractTests.swift
@@ -150,6 +150,82 @@ final class RuntimeContractTests: XCTestCase {
         XCTAssertEqual(desc.name, "scheduled-cleanup")
         XCTAssertEqual(desc.metadata.criticality, .critical)
     }
+
+    // MARK: - Kind mismatch precondition
+    //
+    // These tests verify that passing the wrong `kind` to a descriptor
+    // triggers a precondition failure. We cannot directly test precondition
+    // crashes in XCTest without process isolation, so instead we verify
+    // that correct-kind paths work and document the invariant.
+
+    func testTaskDescriptorCorrectKindAccepted() {
+        let meta = HeliosRuntimeMetadata(name: "valid", kind: .task)
+        let desc = HeliosTaskDescriptor(metadata: meta) { _ in RCStubTask() }
+        XCTAssertEqual(desc.metadata.kind, .task)
+    }
+
+    func testTimerDescriptorCorrectKindAccepted() {
+        let meta = HeliosRuntimeMetadata(name: "valid", kind: .timer)
+        let desc = HeliosTimerDescriptor(metadata: meta) { _ in RCStubTimer() }
+        XCTAssertEqual(desc.metadata.kind, .timer)
+    }
+
+    func testTaskDescriptorTypeBasedCorrectKind() {
+        let meta = HeliosRuntimeMetadata(name: "typed", kind: .task, criticality: .critical)
+        let desc = HeliosTaskDescriptor(metadata: meta, task: RCStubTask.self)
+        XCTAssertEqual(desc.metadata.kind, .task)
+        XCTAssertEqual(desc.metadata.criticality, .critical)
+    }
+
+    func testTimerDescriptorTypeBasedCorrectKind() {
+        let meta = HeliosRuntimeMetadata(name: "typed", kind: .timer, retryPolicy: .fixed(maxAttempts: 1))
+        let desc = HeliosTimerDescriptor(metadata: meta, timer: RCStubTimer.self)
+        XCTAssertEqual(desc.metadata.kind, .timer)
+        XCTAssertEqual(desc.metadata.retryPolicy, .fixed(maxAttempts: 1))
+    }
+
+    // MARK: - Shutdown contract (documented behavior)
+    //
+    // These tests verify the shutdown contract rules are reflected in the
+    // type system and metadata. Full shutdown behavior testing requires
+    // integration with a running Vapor Application and is out of scope
+    // for unit tests.
+
+    func testCriticalTaskMetadataPreserved() {
+        // Rule: critical tasks should be identifiable for future grace-period shutdown
+        let meta = HeliosRuntimeMetadata(
+            name: "critical-cleanup",
+            kind: .task,
+            criticality: .critical,
+            retryPolicy: .fixed(maxAttempts: 3)
+        )
+        let desc = HeliosTaskDescriptor(metadata: meta, task: RCStubTask.self)
+        XCTAssertEqual(desc.metadata.criticality, .critical)
+        XCTAssertEqual(desc.metadata.retryPolicy, .fixed(maxAttempts: 3))
+        // Metadata is available for shutdown coordinator to inspect
+        XCTAssertEqual(desc.metadata.name, "critical-cleanup")
+    }
+
+    func testCriticalTimerMetadataPreserved() {
+        let meta = HeliosRuntimeMetadata(
+            name: "heartbeat",
+            kind: .timer,
+            criticality: .critical,
+            scheduleDescription: "every 30s"
+        )
+        let desc = HeliosTimerDescriptor(metadata: meta, timer: RCStubTimer.self)
+        XCTAssertEqual(desc.metadata.criticality, .critical)
+        XCTAssertEqual(desc.metadata.scheduleDescription, "every 30s")
+    }
+
+    func testRetryPolicyLogDescriptionForShutdownDiagnostics() {
+        // Rule: cancellation path must be visible in logs
+        // logDescription is used in registration logging and should work
+        // for all policy variants
+        XCTAssertEqual(HeliosRetryPolicy.noRetry.logDescription, "none")
+        XCTAssertEqual(HeliosRetryPolicy.fixed(maxAttempts: 1).logDescription, "fixed(1)")
+        XCTAssertEqual(HeliosRetryPolicy.fixed(maxAttempts: 10).logDescription, "fixed(10)")
+    }
 }
 
 // MARK: - Test Fixtures


### PR DESCRIPTION
## Summary

Runtime contract 第二部分——shutdown/cancellation 规则 + Jarvis review 反馈的 kind 不变量约束。

## 改动

### 新增
- **`Docs/RuntimeContract-Shutdown.md`** — 4 条 shutdown/cancellation 行为规则文档
- **7 个新测试**：kind 校验、critical metadata 保持、shutdown contract 覆盖

### 修改
- **`HeliosTaskDescriptor`** — `init(metadata:...)` 增加 `precondition(metadata.kind == .task)`
- **`HeliosTimerDescriptor`** — `init(metadata:...)` 增加 `precondition(metadata.kind == .timer)`

### Shutdown Contract 4 条规则
1. 不保证 in-flight 任务执行完成
2. shutdown 后不接新任务/调度
3. 不静默吞掉 cancellation
4. cancellation 路径在日志中可见（name + kind）

### 兼容性
- 所有现有调用不受影响（convenience init 自动设置正确的 kind）
- 173 个测试全部通过

### 来源
- Kind precondition：来自 Jarvis 在 PR #40 review 中的建议
- Shutdown contract：Issue #27 Step 4（Jarvis 原方案）