### PR TITLE
polish: add Hashable to metadata types, logging for legacy builders

### DIFF
--- a/Sources/Helios/App/HeliosApp.swift
+++ b/Sources/Helios/App/HeliosApp.swift
@@ -230,6 +230,7 @@ public final class HeliosApp {
                 delegate.timers(app: self).forEach { builder in
                     let timer = builder(timerContext)
                     timer.schedule(queue: app.queues)
+                    app.logger.info("Helios: registered timer (legacy builder)")
                 }
             }
         }
@@ -255,6 +256,7 @@ public final class HeliosApp {
                     return
                 }
                 task.register(queue: app.queues)
+                app.logger.info("Helios: registered task (legacy builder)")
             }
         }
     }

--- a/Sources/Helios/Plugins/HeliosRuntimeMetadata.swift
+++ b/Sources/Helios/Plugins/HeliosRuntimeMetadata.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Runtime metadata attached to every Task / Timer descriptor.
-public struct HeliosRuntimeMetadata: Equatable, Sendable {
+public struct HeliosRuntimeMetadata: Equatable, Hashable, Sendable {
 
     /// Human-readable name for logging / debugging.
     public let name: String
@@ -43,17 +43,17 @@ public struct HeliosRuntimeMetadata: Equatable, Sendable {
 
 // MARK: - Supporting Types
 
-public enum HeliosRuntimeKind: String, Equatable, Sendable {
+public enum HeliosRuntimeKind: String, Equatable, Hashable, Sendable {
     case task
     case timer
 }
 
-public enum HeliosCriticality: String, Equatable, Sendable {
+public enum HeliosCriticality: String, Equatable, Hashable, Sendable {
     case normal
     case critical
 }
 
-public enum HeliosRetryPolicy: Equatable, Sendable {
+public enum HeliosRetryPolicy: Equatable, Hashable, Sendable {
     case noRetry
     case fixed(maxAttempts: Int)
 }

--- a/Tests/HeliosTests/RuntimeContractTests.swift
+++ b/Tests/HeliosTests/RuntimeContractTests.swift
@@ -46,14 +46,6 @@ final class RuntimeContractTests: XCTestCase {
         XCTAssertNotEqual(lhs, other)
     }
 
-    func testMetadataHashable() {
-        let meta1 = HeliosRuntimeMetadata(name: "job-a", kind: .task)
-        let meta2 = HeliosRuntimeMetadata(name: "job-a", kind: .task)
-        let meta3 = HeliosRuntimeMetadata(name: "job-b", kind: .timer)
-        let set: Set<HeliosRuntimeMetadata> = [meta1, meta2, meta3]
-        XCTAssertEqual(set.count, 2)
-    }
-
     // MARK: - HeliosRuntimeKind
 
     func testRuntimeKindRawValues() {

--- a/Tests/HeliosTests/RuntimeContractTests.swift
+++ b/Tests/HeliosTests/RuntimeContractTests.swift
@@ -46,6 +46,14 @@ final class RuntimeContractTests: XCTestCase {
         XCTAssertNotEqual(lhs, other)
     }
 
+    func testMetadataHashable() {
+        let meta1 = HeliosRuntimeMetadata(name: "job-a", kind: .task)
+        let meta2 = HeliosRuntimeMetadata(name: "job-a", kind: .task)
+        let meta3 = HeliosRuntimeMetadata(name: "job-b", kind: .timer)
+        let set: Set<HeliosRuntimeMetadata> = [meta1, meta2, meta3]
+        XCTAssertEqual(set.count, 2)
+    }
+
     // MARK: - HeliosRuntimeKind
 
     func testRuntimeKindRawValues() {


### PR DESCRIPTION
## Summary

独立 review #27 后发现的两个小疏漏修复。

## 改动

1. **`Hashable` conformance** — `HeliosRuntimeMetadata`、`HeliosRuntimeKind`、`HeliosCriticality`、`HeliosRetryPolicy` 全部加上 `Hashable`，使 metadata 可用作 Dictionary key / Set 成员
2. **Legacy builder 注册日志** — `registerBackgroundJobs()` 的 legacy builder 路径（timer 和 task）现在也输出 info 级别注册日志，与 descriptor 路径保持 observability 对等
3. **新增 `testMetadataHashable`** — 验证 Set 去重行为

174 测试全部通过。

## 来源

独立 review 时发现：https://github.com/enums/Helios/issues/27#issuecomment-4222099676